### PR TITLE
feat(alb): Add default HTTPS ALB Listener

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,8 @@ No modules.
 
 | Name | Type |
 |------|------|
+| [aws_acm_certificate.default](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/acm_certificate) | resource |
+| [aws_acm_certificate_validation.default](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/acm_certificate_validation) | resource |
 | [aws_autoscaling_group.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/autoscaling_group) | resource |
 | [aws_default_security_group.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/default_security_group) | resource |
 | [aws_ecs_capacity_provider.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ecs_capacity_provider) | resource |
@@ -44,8 +46,10 @@ No modules.
 | [aws_internet_gateway.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/internet_gateway) | resource |
 | [aws_launch_template.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/launch_template) | resource |
 | [aws_lb.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lb) | resource |
+| [aws_lb_listener.https](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lb_listener) | resource |
 | [aws_nat_gateway.nat_a](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/nat_gateway) | resource |
 | [aws_route.cudl_vpc_ec2_route_igw](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route) | resource |
+| [aws_route53_record.acm_validation_cname](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
 | [aws_route53_zone.public](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_zone) | resource |
 | [aws_route_table.main](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route_table) | resource |
 | [aws_route_table.private_a](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route_table) | resource |
@@ -83,6 +87,7 @@ No modules.
 | [aws_iam_policy_document.assume_role_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_kms_alias.ebs](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/kms_alias) | data source |
 | [aws_region.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/region) | data source |
+| [aws_route53_zone.existing](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/route53_zone) | data source |
 
 ## Inputs
 
@@ -94,10 +99,15 @@ No modules.
 | <a name="input_alb_enable_deletion_protection"></a> [alb\_enable\_deletion\_protection](#input\_alb\_enable\_deletion\_protection) | Whether to enable deletion protection for the ALB | `bool` | `true` | no |
 | <a name="input_alb_idle_timeout"></a> [alb\_idle\_timeout](#input\_alb\_idle\_timeout) | Idle timeout for load balancer | `string` | `"60"` | no |
 | <a name="input_alb_internal"></a> [alb\_internal](#input\_alb\_internal) | Whether the ALB should be internal (not public facing) | `bool` | `false` | no |
+| <a name="input_alb_listener_fixed_response_content_type"></a> [alb\_listener\_fixed\_response\_content\_type](#input\_alb\_listener\_fixed\_response\_content\_type) | Default content type for the fixed response of the default ALB Listener | `string` | `"text/html"` | no |
+| <a name="input_alb_listener_fixed_response_message_body"></a> [alb\_listener\_fixed\_response\_message\_body](#input\_alb\_listener\_fixed\_response\_message\_body) | Default message body for the fixed response of the default ALB Listener | `string` | `"<!DOCTYPE html><body><h1>Hello World!</h1></body>"` | no |
+| <a name="input_alb_listener_fixed_response_status_code"></a> [alb\_listener\_fixed\_response\_status\_code](#input\_alb\_listener\_fixed\_response\_status\_code) | Default status code for the fixed response of the default ALB Listener | `string` | `"200"` | no |
+| <a name="input_alb_listener_ssl_policy"></a> [alb\_listener\_ssl\_policy](#input\_alb\_listener\_ssl\_policy) | TLS security policy used by the default ALB Listener | `string` | `"ELBSecurityPolicy-TLS13-1-2-2021-06"` | no |
+| <a name="input_ami_architecture"></a> [ami\_architecture](#input\_ami\_architecture) | Name of the OS Architecture. Note must be compatible with the selected EC2 Instance Type | `string` | `"x86_64"` | no |
 | <a name="input_ami_name_prefix"></a> [ami\_name\_prefix](#input\_ami\_name\_prefix) | Prefix used to find an AMI for use in the Launch Template | `string` | `"amzn2-ami-ecs-hvm-2.0*"` | no |
 | <a name="input_asg_default_cooldown"></a> [asg\_default\_cooldown](#input\_asg\_default\_cooldown) | Number of seconds between scaling activities | `number` | `300` | no |
 | <a name="input_asg_desired_capacity"></a> [asg\_desired\_capacity](#input\_asg\_desired\_capacity) | Desired number of instances in the Autoscaling Group | `number` | `1` | no |
-| <a name="input_asg_enabled_metrics"></a> [asg\_enabled\_metrics](#input\_asg\_enabled\_metrics) | List of metrics enabled for the Auotscaling Group | `list(string)` | <pre>[<br>"GroupTotalInstances",<br>"GroupInServiceInstances",<br>"GroupTerminatingInstances",<br>"GroupPendingInstances",<br>"GroupInServiceCapacity",<br>"GroupPendingCapacity",<br>"GroupTotalCapacity",<br>"GroupTerminatingCapacity"<br>]</pre> | no |
+| <a name="input_asg_enabled_metrics"></a> [asg\_enabled\_metrics](#input\_asg\_enabled\_metrics) | List of metrics enabled for the Auotscaling Group | `list(string)` | <pre>[<br>  "GroupTotalInstances",<br>  "GroupInServiceInstances",<br>  "GroupTerminatingInstances",<br>  "GroupPendingInstances",<br>  "GroupInServiceCapacity",<br>  "GroupPendingCapacity",<br>  "GroupTotalCapacity",<br>  "GroupTerminatingCapacity"<br>]</pre> | no |
 | <a name="input_asg_health_check_grace_period"></a> [asg\_health\_check\_grace\_period](#input\_asg\_health\_check\_grace\_period) | Grace Period before health checks are enabled. ECS Services can take 10 minutes to stabilise | `number` | `600` | no |
 | <a name="input_asg_health_check_type"></a> [asg\_health\_check\_type](#input\_asg\_health\_check\_type) | Type of health check for the Autoscaling Group. Can be EC2 or ELB | `string` | `"EC2"` | no |
 | <a name="input_asg_max_size"></a> [asg\_max\_size](#input\_asg\_max\_size) | Maximum number of instances in the Autoscaling Group | `number` | `1` | no |
@@ -129,6 +139,7 @@ No modules.
 |------|-------------|
 | <a name="output_alb_arn"></a> [alb\_arn](#output\_alb\_arn) | ARN of the Application Load Balancer |
 | <a name="output_alb_dns_name"></a> [alb\_dns\_name](#output\_alb\_dns\_name) | DNS Name of the Application Load Balancer |
+| <a name="output_alb_https_listener_arn"></a> [alb\_https\_listener\_arn](#output\_alb\_https\_listener\_arn) | ARN of the default Application Load Balancer Listener on port 443 |
 | <a name="output_alb_security_group_id"></a> [alb\_security\_group\_id](#output\_alb\_security\_group\_id) | ID of the Security Group for the Application Load Balancer |
 | <a name="output_asg_name"></a> [asg\_name](#output\_asg\_name) | Name of the Auto Scaling Group |
 | <a name="output_asg_security_group_id"></a> [asg\_security\_group\_id](#output\_asg\_security\_group\_id) | ID of the Security Group for the Auto Scaling Group |

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This Terraform module builds the base AWS infrastructure needed to support ECS S
 
 The module will by default build an Auto Scaling Group in private subnets. VPC Endpoints create links to AWS services that will allow the ECS Services to run, as well as accessing ECR repositories.
 
-By default the `ec2_keypair` variable is null, and no Security Group rules allow for SSH access. EC2 instances can be accessed using AWS Session Manager. 
+By default the `ec2_keypair` input is null, and no Security Group rules allow for SSH access. EC2 instances can be accessed using AWS Session Manager. 
 
 In order to provide a running ECS Service, a child module will need to build it's own ECS Service and ECS Task Definition objects, in addition to an ECR Repository. It will not be possible to use publicly available container images as instances in private subnets will have no outbound route to the internet.
 
@@ -154,9 +154,11 @@ No modules.
 
 ## Note about Route 53 Hosted Zone
 
-The name of the Route 53 Hosted Zone needs to match the value of a registered domain name. This registered domain has been created manually in the AWS Route 53 Console. There is an option to manage a registered domain in Terraform, but we feel it is best to avoid unintended to changes to the domain and this has been intentionally omitted from the configuration.
+The name of the Route 53 Hosted Zone needs to match the value of a registered domain name. There is an option to manage an AWS registered domain in Terraform, but we feel it is best to avoid unintended to changes to the domain and this has been intentionally omitted from the configuration.
 
-The registered domain specifies Name Servers which are used to resolve DNS queries for addresses in the domain. These can be set to the name servers created by a Route 53 Hosted Zone. However, given the hosted zone is managed by Terraform and may be replaced or destroyed, particularly in a sandbox environment, this could lead to frequent changes to the registered domain name servers. These would need to be made manually.
+This module is able to optionally build a Route 53 hosted zone, or to look up an existing hosted zone using the input `route53_zone_id_existing`.
+
+In AWS a Registered Domain specifies Name Servers which are used to resolve DNS queries for addresses in the domain. These can be set to the name servers created by a Route 53 Hosted Zone. However, given the hosted zone is managed by Terraform and may be replaced or destroyed, particularly in a sandbox environment, this could lead to frequent changes to the registered domain name servers. These would need to be made manually.
 
 To avoid this, it is possible to create a Delegation Set to act as a bridge between the registered domain and the Route 53 Hosted Zone. To avoid this also changing frequently, it should be created outside Terraform. This can be done with the AWS CLI.
 
@@ -164,7 +166,9 @@ To avoid this, it is possible to create a Delegation Set to act as a bridge betw
 aws route53 create-reusable-delegation-set --caller-reference "$(date +"%s")"
 ```
 
-This will output an Id attribute in the format "/delegationset/N10230772EN8U28YG7Z00". The second part of this ID (the unique reference) should be passed to the route53_delegation_set_id input for this module. When the Route 53 Hosted Zone is created it will use the name servers specified in the delegation set. When the registered domain is updated to use the name servers listed in the output for the command above, this will allow the hosted zone to be changed without needing to update the name server details again.
+This will output an Id attribute in the format "/delegationset/N10230772EN8U28YG7Z00". The second part of this ID (the unique reference) can be passed to the route53_delegation_set_id input for this module. If a Route 53 Hosted Zone is created by this module it is able to use the name servers specified in the delegation set. When the registered domain is updated to use the name servers listed in the output for the command above, this will allow the hosted zone to be changed without needing to update the name server details again.
+
+Note that it is not possible to have two Route 53 hosted zones using the same domain name and the same name servers. A delegation set can only be used with a set of unique domain names.
 
 ## Note about Auto Scaling Group Health Check Type
 
@@ -175,7 +179,33 @@ Using the ELB health check type has some implications:
 - Initially, it this module is built without any dependent service there will be no way of fulfilling the ASG health check as there will be no target groups. This will lead to continuous instance cycling.
 - Where multiple dependent services have been built on top of the same implementation of this module, the failure of one of these services will fail them all. This will impact otherwise healthy services.
 
-The default value for the `asg_health_check_type` variable has therefore been set to `EC2`. For implementations with a small number of stable services the value of `ELB` may be preferred as this provides a truer reflection of service health.
+The default value for the `asg_health_check_type` input has therefore been set to `EC2`. For implementations with a small number of stable services the value of `ELB` may be preferred as this provides a truer reflection of service health.
+
+## Note about Load Balancer Listener
+
+AWS does not permit multiple listeners on the same Load Balancer using the same port. This could mean that only one target was available on the default HTTPs port 443. A solution to this is to generate a "default" load balancer listener assigned to port 443. The output `alb_https_listener_arn` allows dependent modules to build their own `aws_lb_listener_rule` resources referring to the ARN of the listener. This allows a single port to front several targets, using rules to determine the correct target.
+
+An implementation of this could use the host_header condition to route requests using the value of the Host header sent by the client (note this header will be automatically inserted by most HTTP user agents such as curl). For example:
+
+```hcl
+resource "aws_lb_listener_rule" "this" {
+  listener_arn = var.alb_listener_arn
+  priority     = var.alb_listener_rule_priority
+
+  action {
+    type             = "forward"
+    target_group_arn = aws_lb_target_group.this.arn
+  }
+
+  condition {
+    host_header {
+      values = [aws_route53_record.this.name]
+    }
+  }
+}
+```
+
+The certificate `aws_acm_certificate.default` in this module has no corresponding Route 53 A record - therefore requests to the domain name of the certificate will fail. This is by design. It is not possible to create a Load Balancer listener using the HTTPs protocol without referring to a certificate, and the resource here allows this. The domain name of the default certificate is not output by this module as it is not intended for re-use. 
 
 ## GitHub Workflows
 

--- a/acm.tf
+++ b/acm.tf
@@ -3,6 +3,7 @@ locals {
   default_domain_name      = lower(trim(substr(join(".", ["default", var.name_prefix, local.route53_zone_domain_name]), -64, -1), ".-"))
 }
 
+# NOTE see section "Note about Load Balancer Listener" in README.md
 resource "aws_acm_certificate" "default" {
   domain_name = local.default_domain_name
   subject_alternative_names = [

--- a/acm.tf
+++ b/acm.tf
@@ -1,0 +1,25 @@
+locals {
+  route53_zone_domain_name = var.route53_zone_id_existing != null ? data.aws_route53_zone.existing.0.name : aws_route53_zone.public.0.name
+  default_domain_name      = lower(trim(substr(join(".", ["default", var.name_prefix, local.route53_zone_domain_name]), -64, -1), ".-"))
+}
+
+resource "aws_acm_certificate" "default" {
+  domain_name = local.default_domain_name
+  subject_alternative_names = [
+    local.default_domain_name
+  ]
+  validation_method = "DNS"
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+resource "aws_acm_certificate_validation" "default" {
+  certificate_arn         = aws_acm_certificate.default.arn
+  validation_record_fqdns = [for record in aws_route53_record.acm_validation_cname : record.fqdn]
+
+  timeouts {
+    create = "10m"
+  }
+}

--- a/loadbalancer.tf
+++ b/loadbalancer.tf
@@ -22,6 +22,7 @@ resource "aws_lb" "this" {
   }
 }
 
+# NOTE see section "Note about Load Balancer Listener" in README.md
 resource "aws_lb_listener" "https" {
   load_balancer_arn = aws_lb.this.arn
   port              = 443

--- a/loadbalancer.tf
+++ b/loadbalancer.tf
@@ -21,3 +21,25 @@ resource "aws_lb" "this" {
     }
   }
 }
+
+resource "aws_lb_listener" "https" {
+  load_balancer_arn = aws_lb.this.arn
+  port              = 443
+  protocol          = "HTTPS"
+  ssl_policy        = var.alb_listener_ssl_policy
+  certificate_arn   = aws_acm_certificate.default.arn
+
+  default_action {
+    type = "fixed-response"
+
+    fixed_response {
+      content_type = var.alb_listener_fixed_response_content_type
+      message_body = var.alb_listener_fixed_response_message_body
+      status_code  = var.alb_listener_fixed_response_status_code
+    }
+  }
+
+  tags = {
+    Name = "${var.name_prefix}-alb-default-listener"
+  }
+}

--- a/outputs.tf
+++ b/outputs.tf
@@ -23,6 +23,11 @@ output "alb_arn" {
   description = "ARN of the Application Load Balancer"
 }
 
+output "alb_https_listener_arn" {
+  value       = aws_lb_listener.https.arn
+  description = "ARN of the default Application Load Balancer Listener on port 443"
+}
+
 output "alb_dns_name" {
   value       = aws_lb.this.dns_name
   description = "DNS Name of the Application Load Balancer"

--- a/route53.tf
+++ b/route53.tf
@@ -5,3 +5,20 @@ resource "aws_route53_zone" "public" {
   delegation_set_id = var.route53_delegation_set_id
   force_destroy     = var.route53_zone_force_destroy
 }
+
+resource "aws_route53_record" "acm_validation_cname" {
+  for_each = {
+    for dvo in aws_acm_certificate.default.domain_validation_options : dvo.domain_name => {
+      name   = dvo.resource_record_name
+      record = dvo.resource_record_value
+      type   = dvo.resource_record_type
+    }
+  }
+
+  allow_overwrite = true
+  name            = each.value.name
+  records         = [each.value.record]
+  ttl             = 300
+  type            = each.value.type
+  zone_id         = var.route53_zone_id_existing != null ? data.aws_route53_zone.existing.0.zone_id : aws_route53_zone.public.0.zone_id
+}

--- a/variables.tf
+++ b/variables.tf
@@ -204,6 +204,30 @@ variable "alb_enable_deletion_protection" {
   default     = true
 }
 
+variable "alb_listener_ssl_policy" {
+  type        = string
+  description = "TLS security policy used by the default ALB Listener"
+  default     = "ELBSecurityPolicy-TLS13-1-2-2021-06"
+}
+
+variable "alb_listener_fixed_response_content_type" {
+  type        = string
+  description = "Default content type for the fixed response of the default ALB Listener"
+  default     = "text/html"
+}
+
+variable "alb_listener_fixed_response_message_body" {
+  type        = string
+  description = "Default message body for the fixed response of the default ALB Listener"
+  default     = "<!DOCTYPE html><body><h1>Hello World!</h1></body>"
+}
+
+variable "alb_listener_fixed_response_status_code" {
+  type        = string
+  description = "Default status code for the fixed response of the default ALB Listener"
+  default     = "200"
+}
+
 variable "cloudwatch_log_group" {
   type        = string
   description = "Name of the cloudwatch log group"


### PR DESCRIPTION
## Description

Add default HTTPS ALB Listener

## What Changed?

- Add acm.tf with aws_acm_certificate.default and aws_acm_certificate_validation.default resources
- Add aws_route53_record.acm_validation_cname resource
- Add aws_lb_listener.default resource returning a fixed response
- Add alb_listener_fixed_response_content_type, alb_listener_fixed_response_message_body and alb_listener_fixed_response_status_code variables to set the fixed response of the ALB listener
- Add alb_listener_ssl_policy variable to set the security policy of the listener
- Add output alb_https_listener_arn
- Update README.md

## Reason For Change

AWS does not allow multiple load balancer listeners to use the same port. The new listener resource creates a common listener on port 443 that can be consumed by dependent modules allowing multiple targets to receive traffic via the default HTTPs port 443

## Checklist For Reviewer

- [ ] You understand the reason for the change and how it fits into the existing codebase
- [ ] For changes that relate to a deployment, you understand how the change will affect any dependent Live environments
- [ ] You understand the scope of the change and the commit messages reflect this, e.g. where you consider the change to be a breaking change, at least one commit message should include the body "BREAKING CHANGE: ..."
- [ ] You have requested changes to the Pull Request if required, or raised comments suggesting improvements
- [ ] All Review comments and requests for changes have been resolved, or assigned Issues
- [ ] All GitHub Actions jobs pass
