### PR TITLE
Feature/vpc endpoints s3

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,8 +20,8 @@ No requirements.
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | n/a |
-| <a name="provider_aws.us-east-1"></a> [aws.us-east-1](#provider\_aws.us-east-1) | n/a |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 5.50.0 |
+| <a name="provider_aws.us-east-1"></a> [aws.us-east-1](#provider\_aws.us-east-1) | 5.50.0 |
 
 ## Modules
 
@@ -65,9 +65,9 @@ No modules.
 | [aws_security_group.asg](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group) | resource |
 | [aws_security_group.vpc_endpoints](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group) | resource |
 | [aws_security_group_rule.alb_ingress_cloudfront](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
-| [aws_security_group_rule.asg_egress_s3](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
 | [aws_security_group_rule.vpc_endpoint_egress_self](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
 | [aws_security_group_rule.vpc_endpoint_ingress_self](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
+| [aws_security_group_rule.vpc_endpoints_egress_s3](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
 | [aws_subnet.private_a](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/subnet) | resource |
 | [aws_subnet.private_b](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/subnet) | resource |
 | [aws_subnet.public_a](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/subnet) | resource |

--- a/README.md
+++ b/README.md
@@ -146,6 +146,7 @@ No modules.
 | <a name="output_cloudwatch_log_group_arn"></a> [cloudwatch\_log\_group\_arn](#output\_cloudwatch\_log\_group\_arn) | ARN of the CloudWatch Log Group |
 | <a name="output_cloudwatch_log_group_name"></a> [cloudwatch\_log\_group\_name](#output\_cloudwatch\_log\_group\_name) | Name of the CloudWatch Log Group |
 | <a name="output_ecs_cluster_arn"></a> [ecs\_cluster\_arn](#output\_ecs\_cluster\_arn) | ARN of the ECS Cluster |
+| <a name="output_ecs_cluster_name"></a> [ecs\_cluster\_name](#output\_ecs\_cluster\_name) | Name of the ECS Cluster |
 | <a name="output_route53_public_hosted_zone"></a> [route53\_public\_hosted\_zone](#output\_route53\_public\_hosted\_zone) | Zone ID of the Route 53 Public Hosted Zone |
 | <a name="output_s3_bucket"></a> [s3\_bucket](#output\_s3\_bucket) | Name of the S3 Bucket |
 | <a name="output_s3_bucket_arn"></a> [s3\_bucket\_arn](#output\_s3\_bucket\_arn) | ARN of the S3 Bucket |

--- a/README.md
+++ b/README.md
@@ -150,6 +150,8 @@ No modules.
 | <a name="output_s3_bucket"></a> [s3\_bucket](#output\_s3\_bucket) | Name of the S3 Bucket |
 | <a name="output_s3_bucket_arn"></a> [s3\_bucket\_arn](#output\_s3\_bucket\_arn) | ARN of the S3 Bucket |
 | <a name="output_vpc_id"></a> [vpc\_id](#output\_vpc\_id) | VPC ID |
+| <a name="output_vpc_private_subnet_ids"></a> [vpc\_private\_subnet\_ids](#output\_vpc\_private\_subnet\_ids) | Private Subnet IDs |
+| <a name="output_vpc_public_subnet_ids"></a> [vpc\_public\_subnet\_ids](#output\_vpc\_public\_subnet\_ids) | Public Subnet IDs |
 | <a name="output_waf_acl_arn"></a> [waf\_acl\_arn](#output\_waf\_acl\_arn) | ARN of the WAF Web ACL |
 
 ## Note about Route 53 Hosted Zone

--- a/outputs.tf
+++ b/outputs.tf
@@ -3,6 +3,16 @@ output "vpc_id" {
   description = "VPC ID"
 }
 
+output "vpc_public_subnet_ids" {
+  value       = [aws_subnet.public_a.id, aws_subnet.public_b.id]
+  description = "Public Subnet IDs"
+}
+
+output "vpc_private_subnet_ids" {
+  value       = [aws_subnet.private_a.id, aws_subnet.private_b.id]
+  description = "Private Subnet IDs"
+}
+
 output "ecs_cluster_arn" {
   value       = aws_ecs_cluster.this.arn
   description = "ARN of the ECS Cluster"

--- a/outputs.tf
+++ b/outputs.tf
@@ -13,6 +13,11 @@ output "vpc_private_subnet_ids" {
   description = "Private Subnet IDs"
 }
 
+output "ecs_cluster_name" {
+  value       = aws_ecs_cluster.this.name
+  description = "Name of the ECS Cluster"
+}
+
 output "ecs_cluster_arn" {
   value       = aws_ecs_cluster.this.arn
   description = "ARN of the ECS Cluster"

--- a/security_groups.tf
+++ b/security_groups.tf
@@ -46,16 +46,6 @@ resource "aws_security_group_rule" "alb_ingress_cloudfront" {
   prefix_list_ids   = [data.aws_ec2_managed_prefix_list.cloudfront.id]
 }
 
-resource "aws_security_group_rule" "asg_egress_s3" {
-  type              = "egress"
-  protocol          = "tcp"
-  description       = "Egress to S3 for ${var.name_prefix}"
-  security_group_id = aws_security_group.asg.id
-  from_port         = 443
-  to_port           = 443
-  prefix_list_ids   = [data.aws_ec2_managed_prefix_list.s3.id]
-}
-
 resource "aws_security_group_rule" "vpc_endpoint_ingress_self" {
   type              = "ingress"
   protocol          = "tcp"
@@ -74,4 +64,14 @@ resource "aws_security_group_rule" "vpc_endpoint_egress_self" {
   from_port         = 443
   to_port           = 443
   self              = true
+}
+
+resource "aws_security_group_rule" "vpc_endpoints_egress_s3" {
+  type              = "egress"
+  protocol          = "tcp"
+  description       = "Egress to S3 for ${var.name_prefix}"
+  security_group_id = aws_security_group.vpc_endpoints.id
+  from_port         = 443
+  to_port           = 443
+  prefix_list_ids   = [data.aws_ec2_managed_prefix_list.s3.id]
 }


### PR DESCRIPTION
## Description

Add S3 egress security group rule to VPC endpoints security group, rather than ASG security group. Also add outputs.

## What Changed?

- Add `aws_security_group_rule.vpc_endpoints_egress_s3`
- Remove `aws_security_group_rule.asg_egress_s3`
- Add outputs `vpc_public_subnet_ids`, `vpc_private_subnet_ids` and `ecs_cluster_name`
- Update README.md

## Reason For Change

The security group change will allow other services, such as Lambdas, to adopt the VPC endpoints security group to access S3 and other VPC endpoints. The additional outputs will be useful to consuming services.

## Checklist For Reviewer

- [ ] You understand the reason for the change and how it fits into the existing codebase
- [ ] For changes that relate to a deployment, you understand how the change will affect any dependent Live environments
- [ ] You understand the scope of the change and the commit messages reflect this, e.g. where you consider the change to be a breaking change, at least one commit message should include the body "BREAKING CHANGE: ..."
- [ ] You have requested changes to the Pull Request if required, or raised comments suggesting improvements
- [ ] All Review comments and requests for changes have been resolved, or assigned Issues
- [ ] All GitHub Actions jobs pass
