### PR TITLE
Feature/vpc peering

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ No modules.
 | [aws_vpc_dhcp_options_association.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/vpc_dhcp_options_association) | resource |
 | [aws_vpc_endpoint.interface](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/vpc_endpoint) | resource |
 | [aws_vpc_endpoint.s3](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/vpc_endpoint) | resource |
+| [aws_vpc_peering_connection.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/vpc_peering_connection) | resource |
 | [aws_wafv2_ip_set.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/wafv2_ip_set) | resource |
 | [aws_wafv2_web_acl.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/wafv2_web_acl) | resource |
 | [aws_ami.ecs_ami](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/ami) | data source |
@@ -130,6 +131,7 @@ No modules.
 | <a name="input_vpc_cidr_block"></a> [vpc\_cidr\_block](#input\_vpc\_cidr\_block) | CIDR block for the VPC | `string` | `"10.0.0.0/16"` | no |
 | <a name="input_vpc_endpoint_dns_record_ip_type"></a> [vpc\_endpoint\_dns\_record\_ip\_type](#input\_vpc\_endpoint\_dns\_record\_ip\_type) | The DNS records created for the endpoint | `string` | `"ipv4"` | no |
 | <a name="input_vpc_endpoint_services"></a> [vpc\_endpoint\_services](#input\_vpc\_endpoint\_services) | List of services to create VPC Endpoints for | `list(string)` | <pre>[<br>  "ssmmessages",<br>  "ssm",<br>  "ec2messages",<br>  "ecr.api",<br>  "ecr.dkr",<br>  "ecs",<br>  "ecs-agent",<br>  "ecs-telemetry",<br>  "logs"<br>]</pre> | no |
+| <a name="input_vpc_peering_vpc_ids"></a> [vpc\_peering\_vpc\_ids](#input\_vpc\_peering\_vpc\_ids) | List of VPC IDS for peering with the VPC | `list(string)` | `[]` | no |
 | <a name="input_vpc_public_subnet_public_ip"></a> [vpc\_public\_subnet\_public\_ip](#input\_vpc\_public\_subnet\_public\_ip) | Whether to automatically assign public IP addresses in the public subnets | `bool` | `false` | no |
 | <a name="input_waf_ip_set_addresses"></a> [waf\_ip\_set\_addresses](#input\_waf\_ip\_set\_addresses) | List of IPs for WAF IP Set Safelist | `list(string)` | <pre>[<br>  "131.111.0.0/16"<br>]</pre> | no |
 

--- a/terraform.tf
+++ b/terraform.tf
@@ -1,0 +1,7 @@
+terraform {
+  required_providers {
+    aws = {
+      source = "hashicorp/aws"
+    }
+  }
+}

--- a/variables.tf
+++ b/variables.tf
@@ -33,6 +33,12 @@ variable "vpc_endpoint_services" {
   default     = ["ssmmessages", "ssm", "ec2messages", "ecr.api", "ecr.dkr", "ecs", "ecs-agent", "ecs-telemetry", "logs"]
 }
 
+variable "vpc_peering_vpc_ids" {
+  type        = list(string)
+  description = "List of VPC IDS for peering with the VPC"
+  default     = []
+}
+
 variable "route53_zone_domain_name" {
   type        = string
   description = "Name of the Domain Name used by the Route 53 Zone. Trailing dots are ignored"

--- a/vpc.tf
+++ b/vpc.tf
@@ -242,3 +242,22 @@ resource "aws_default_security_group" "this" {
     Name = "default"
   }
 }
+
+################################################################################
+# VPC Peering
+################################################################################
+
+resource "aws_vpc_peering_connection" "this" {
+  for_each = toset(var.vpc_peering_vpc_ids)
+
+  peer_vpc_id = aws_vpc.this.id # accepter
+  vpc_id      = each.key        # requester
+
+  accepter {
+    allow_remote_vpc_dns_resolution = false
+  }
+
+  requester {
+    allow_remote_vpc_dns_resolution = true
+  }
+}

--- a/vpc.tf
+++ b/vpc.tf
@@ -252,6 +252,7 @@ resource "aws_vpc_peering_connection" "this" {
 
   peer_vpc_id = aws_vpc.this.id # accepter
   vpc_id      = each.key        # requester
+  auto_accept = true
 
   accepter {
     allow_remote_vpc_dns_resolution = false

--- a/vpc.tf
+++ b/vpc.tf
@@ -255,10 +255,10 @@ resource "aws_vpc_peering_connection" "this" {
   auto_accept = true
 
   accepter {
-    allow_remote_vpc_dns_resolution = false
+    allow_remote_vpc_dns_resolution = true
   }
 
   requester {
-    allow_remote_vpc_dns_resolution = true
+    allow_remote_vpc_dns_resolution = false
   }
 }

--- a/vpc.tf
+++ b/vpc.tf
@@ -255,10 +255,10 @@ resource "aws_vpc_peering_connection" "this" {
   auto_accept = true
 
   accepter {
-    allow_remote_vpc_dns_resolution = true
+    allow_remote_vpc_dns_resolution = true # Allow requester VPC to resolve DNS of hosts in accepter VPC to private IP addresses
   }
 
   requester {
-    allow_remote_vpc_dns_resolution = false
+    allow_remote_vpc_dns_resolution = false # Allow accepter VPC to resolve DNS of hosts in requester VPC to private IP addresses
   }
 }


### PR DESCRIPTION
## Description

Add ability to peer with external VPCs in the same AWS account

## What Changed?

- Add `aws_vpc_peering_connection.this` resource
- Add `terraform.tf` to prevent warnings around missing provider configuration
- Add variable `vpc_peering_vpc_ids`
- Update `README.md`

## Reason For Change

Adding the ability to peer with external VPCs allows ECS services to interact with existing services in other VPCs that cannot be moved

## Checklist For Reviewer

- [ ] You understand the reason for the change and how it fits into the existing codebase
- [ ] For changes that relate to a deployment, you understand how the change will affect any dependent Live environments
- [ ] You understand the scope of the change and the commit messages reflect this, e.g. where you consider the change to be a breaking change, at least one commit message should include the body "BREAKING CHANGE: ..."
- [ ] You have requested changes to the Pull Request if required, or raised comments suggesting improvements
- [ ] All Review comments and requests for changes have been resolved, or assigned Issues
- [ ] All GitHub Actions jobs pass
