### PR TITLE
Feature/ecs cas

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,8 @@ No modules.
 | <a name="input_ec2_ebs_volume_type"></a> [ec2\_ebs\_volume\_type](#input\_ec2\_ebs\_volume\_type) | Volume type used in EBS volumes | `string` | `"gp3"` | no |
 | <a name="input_ec2_instance_type"></a> [ec2\_instance\_type](#input\_ec2\_instance\_type) | EC2 Instance type used by EC2 Instances | `string` | `"t3.small"` | no |
 | <a name="input_ec2_keypair"></a> [ec2\_keypair](#input\_ec2\_keypair) | Name of EC2 Keypair for SSH access to EC2 instances | `string` | `null` | no |
+| <a name="input_ecs_capacity_provider_managed_termination_protection"></a> [ecs\_capacity\_provider\_managed\_termination\_protection](#input\_ecs\_capacity\_provider\_managed\_termination\_protection) | Enables or disables container-aware termination of instances in the ASG when scale-in happens | `string` | `"ENABLED"` | no |
+| <a name="input_ecs_capacity_provider_status"></a> [ecs\_capacity\_provider\_status](#input\_ecs\_capacity\_provider\_status) | Enables or disables managed scaling on ASG | `string` | `"ENABLED"` | no |
 | <a name="input_ecs_capacity_provider_target_capacity_percent"></a> [ecs\_capacity\_provider\_target\_capacity\_percent](#input\_ecs\_capacity\_provider\_target\_capacity\_percent) | Percentage target capacity utilization for the autscaling group instances | `number` | `100` | no |
 | <a name="input_name_prefix"></a> [name\_prefix](#input\_name\_prefix) | Name prefix of the ECS Cluster and associated resources | `string` | n/a | yes |
 | <a name="input_route53_delegation_set_id"></a> [route53\_delegation\_set\_id](#input\_route53\_delegation\_set\_id) | The ID of the reusable delegation set whose NS records should be assigned to the hosted zone | `string` | `null` | no |
@@ -147,6 +149,7 @@ No modules.
 | <a name="output_asg_security_group_id"></a> [asg\_security\_group\_id](#output\_asg\_security\_group\_id) | ID of the Security Group for the Auto Scaling Group |
 | <a name="output_cloudwatch_log_group_arn"></a> [cloudwatch\_log\_group\_arn](#output\_cloudwatch\_log\_group\_arn) | ARN of the CloudWatch Log Group |
 | <a name="output_cloudwatch_log_group_name"></a> [cloudwatch\_log\_group\_name](#output\_cloudwatch\_log\_group\_name) | Name of the CloudWatch Log Group |
+| <a name="output_ecs_capacity_provider_name"></a> [ecs\_capacity\_provider\_name](#output\_ecs\_capacity\_provider\_name) | Name of the ECS Capacity Provider associated with the Autoscaling Group |
 | <a name="output_ecs_cluster_arn"></a> [ecs\_cluster\_arn](#output\_ecs\_cluster\_arn) | ARN of the ECS Cluster |
 | <a name="output_ecs_cluster_name"></a> [ecs\_cluster\_name](#output\_ecs\_cluster\_name) | Name of the ECS Cluster |
 | <a name="output_route53_public_hosted_zone"></a> [route53\_public\_hosted\_zone](#output\_route53\_public\_hosted\_zone) | Zone ID of the Route 53 Public Hosted Zone |

--- a/ecs.tf
+++ b/ecs.tf
@@ -9,12 +9,12 @@ resource "aws_ecs_capacity_provider" "this" {
 
   auto_scaling_group_provider {
     auto_scaling_group_arn         = aws_autoscaling_group.this.arn
-    managed_termination_protection = "DISABLED"
+    managed_termination_protection = var.ecs_capacity_provider_managed_termination_protection
 
     managed_scaling {
       maximum_scaling_step_size = 2
       minimum_scaling_step_size = 1
-      status                    = "ENABLED"
+      status                    = var.ecs_capacity_provider_status
       target_capacity           = var.ecs_capacity_provider_target_capacity_percent
     }
   }

--- a/outputs.tf
+++ b/outputs.tf
@@ -23,6 +23,11 @@ output "ecs_cluster_arn" {
   description = "ARN of the ECS Cluster"
 }
 
+output "ecs_capacity_provider_name" {
+  value       = aws_ecs_capacity_provider.this.name
+  description = "Name of the ECS Capacity Provider associated with the Autoscaling Group"
+}
+
 output "s3_bucket" {
   value       = aws_s3_bucket.this.id
   description = "Name of the S3 Bucket"

--- a/variables.tf
+++ b/variables.tf
@@ -168,10 +168,22 @@ variable "asg_enabled_metrics" {
   ]
 }
 
+variable "ecs_capacity_provider_status" {
+  type        = string
+  description = "Enables or disables managed scaling on ASG"
+  default     = "ENABLED"
+}
+
 variable "ecs_capacity_provider_target_capacity_percent" {
   type        = number
   description = "Percentage target capacity utilization for the autscaling group instances"
   default     = 100
+}
+
+variable "ecs_capacity_provider_managed_termination_protection" {
+  type        = string
+  description = "Enables or disables container-aware termination of instances in the ASG when scale-in happens"
+  default     = "ENABLED"
 }
 
 variable "alb_internal" {


### PR DESCRIPTION
## Description

Add inputs and outputs relating to ECS Capacity Provider

## What Changed?

- Add inputs `ecs_capacity_provider_managed_termination_protection` and `ecs_capacity_provider_status` both defaulting to "ENABLED"
- Add output `ecs_capacity_provider_name`

## Reason For Change

The new inputs allow the default ECS Capacity Provider to be adjusted, including being disabled. The new output exposes the name of the capacity provider, allowing this to be consumed by dependent projects

## Checklist For Reviewer

- [ ] You understand the reason for the change and how it fits into the existing codebase
- [ ] For changes that relate to a deployment, you understand how the change will affect any dependent Live environments
- [ ] You understand the scope of the change and the commit messages reflect this, e.g. where you consider the change to be a breaking change, at least one commit message should include the body "BREAKING CHANGE: ..."
- [ ] You have requested changes to the Pull Request if required, or raised comments suggesting improvements
- [ ] All Review comments and requests for changes have been resolved, or assigned Issues
- [ ] All GitHub Actions jobs pass
