### PR TITLE
Add NAT gateway in B subnets

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ No modules.
 | [aws_ecs_cluster.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ecs_cluster) | resource |
 | [aws_ecs_cluster_capacity_providers.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ecs_cluster_capacity_providers) | resource |
 | [aws_eip.nat_a](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/eip) | resource |
+| [aws_eip.nat_b](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/eip) | resource |
 | [aws_iam_instance_profile.instance](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_instance_profile) | resource |
 | [aws_iam_role.instance](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
 | [aws_iam_role_policy_attachment.ec2_container_service](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
@@ -48,6 +49,7 @@ No modules.
 | [aws_lb.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lb) | resource |
 | [aws_lb_listener.https](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lb_listener) | resource |
 | [aws_nat_gateway.nat_a](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/nat_gateway) | resource |
+| [aws_nat_gateway.nat_b](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/nat_gateway) | resource |
 | [aws_route.cudl_vpc_ec2_route_igw](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route) | resource |
 | [aws_route53_record.acm_validation_cname](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
 | [aws_route53_zone.public](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_zone) | resource |

--- a/vpc.tf
+++ b/vpc.tf
@@ -97,7 +97,10 @@ resource "aws_route_table" "private_a" {
 resource "aws_route_table" "private_b" {
   vpc_id = aws_vpc.this.id
 
-  # NOTE missing route
+  route {
+    cidr_block     = "0.0.0.0/0"
+    nat_gateway_id = aws_nat_gateway.nat_b.id
+  }
 
   tags = {
     Name = "${var.name_prefix}-rtb-private_${data.aws_region.current.name}b"
@@ -222,11 +225,32 @@ resource "aws_nat_gateway" "nat_a" {
   depends_on = [aws_internet_gateway.this]
 }
 
+resource "aws_nat_gateway" "nat_b" {
+  allocation_id = aws_eip.nat_b.id
+  subnet_id     = aws_subnet.public_b.id
+
+  tags = {
+    Name = "${var.name_prefix}-nat-b"
+  }
+
+  # To ensure proper ordering, it is recommended to add an explicit dependency
+  # on the Internet Gateway for the VPC.
+  depends_on = [aws_internet_gateway.this]
+}
+
 resource "aws_eip" "nat_a" {
   domain = "vpc"
 
   tags = {
     Name = "${var.name_prefix}-nat-1a-elastic-ip"
+  }
+}
+
+resource "aws_eip" "nat_b" {
+  domain = "vpc"
+
+  tags = {
+    Name = "${var.name_prefix}-nat-1b-elastic-ip"
   }
 }
 


### PR DESCRIPTION
## Description

Add missing NAT Gateway allowing internet egress in private "B" subnets, e.g. `eu-west-1b`

## What Changed?

- Add `aws_nat_gateway.nat_b` and `aws_eip.nat_b`
- Add route to `aws_nat_gateway.nat_b` in `aws_route_table.private_b`
- Update `README.md`

## Reason For Change

Currently services built in "A" subnets can reach the internet via the existing NAT Gateway, however services in "B" subnets cannot

## Checklist For Reviewer

- [ ] You understand the reason for the change and how it fits into the existing codebase
- [ ] For changes that relate to a deployment, you understand how the change will affect any dependent Live environments
- [ ] You understand the scope of the change and the commit messages reflect this, e.g. where you consider the change to be a breaking change, at least one commit message should include the body "BREAKING CHANGE: ..."
- [ ] You have requested changes to the Pull Request if required, or raised comments suggesting improvements
- [ ] All Review comments and requests for changes have been resolved, or assigned Issues
- [ ] All GitHub Actions jobs pass
