### PR TITLE
feat(output): Add vpc_endpoint_security_group_id output

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,6 +157,7 @@ No modules.
 | <a name="output_route53_public_hosted_zone"></a> [route53\_public\_hosted\_zone](#output\_route53\_public\_hosted\_zone) | Zone ID of the Route 53 Public Hosted Zone |
 | <a name="output_s3_bucket"></a> [s3\_bucket](#output\_s3\_bucket) | Name of the S3 Bucket |
 | <a name="output_s3_bucket_arn"></a> [s3\_bucket\_arn](#output\_s3\_bucket\_arn) | ARN of the S3 Bucket |
+| <a name="output_vpc_endpoint_security_group_id"></a> [vpc\_endpoint\_security\_group\_id](#output\_vpc\_endpoint\_security\_group\_id) | ID of the Security Group for VPC Endpoints |
 | <a name="output_vpc_id"></a> [vpc\_id](#output\_vpc\_id) | VPC ID |
 | <a name="output_vpc_private_subnet_ids"></a> [vpc\_private\_subnet\_ids](#output\_vpc\_private\_subnet\_ids) | Private Subnet IDs |
 | <a name="output_vpc_public_subnet_ids"></a> [vpc\_public\_subnet\_ids](#output\_vpc\_public\_subnet\_ids) | Public Subnet IDs |

--- a/outputs.tf
+++ b/outputs.tf
@@ -68,6 +68,11 @@ output "asg_security_group_id" {
   description = "ID of the Security Group for the Auto Scaling Group"
 }
 
+output "vpc_endpoint_security_group_id" {
+  value       = aws_security_group.vpc_endpoints.id
+  description = "ID of the Security Group for VPC Endpoints"
+}
+
 output "route53_public_hosted_zone" {
   value       = coalescelist(data.aws_route53_zone.existing.*.id, aws_route53_zone.public.*.id)[0]
   description = "Zone ID of the Route 53 Public Hosted Zone"


### PR DESCRIPTION
## Description

Add `vpc_endpoint_security_group_id` output

## What Changed?

Add `vpc_endpoint_security_group_id` output in `outputs.tf`

## Reason For Change

Exposing the VPC endpoint security group ID allows ECS tasks using `awsvpc` networking mode to consume the security group, allowing them to access AWS APIs using internal routes

## Checklist For Reviewer

- [ ] You understand the reason for the change and how it fits into the existing codebase
- [ ] For changes that relate to a deployment, you understand how the change will affect any dependent Live environments
- [ ] You understand the scope of the change and the commit messages reflect this, e.g. where you consider the change to be a breaking change, at least one commit message should include the body "BREAKING CHANGE: ..."
- [ ] You have requested changes to the Pull Request if required, or raised comments suggesting improvements
- [ ] All Review comments and requests for changes have been resolved, or assigned Issues
- [ ] All GitHub Actions jobs pass
