### PR TITLE
fix(asg): Fix error creating ECS capacity provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,7 @@ No modules.
 | <a name="input_asg_max_size"></a> [asg\_max\_size](#input\_asg\_max\_size) | Maximum number of instances in the Autoscaling Group | `number` | `1` | no |
 | <a name="input_asg_metrics_granularity"></a> [asg\_metrics\_granularity](#input\_asg\_metrics\_granularity) | Granularity of metrics collected by the Autoscaling Group | `string` | `"1Minute"` | no |
 | <a name="input_asg_min_size"></a> [asg\_min\_size](#input\_asg\_min\_size) | Minimum number of instances in the Autoscaling Group | `number` | `1` | no |
+| <a name="input_asg_protect_from_scale_in"></a> [asg\_protect\_from\_scale\_in](#input\_asg\_protect\_from\_scale\_in) | Whether newly launched instances are automatically protected from termination | `bool` | `true` | no |
 | <a name="input_asg_termination_policies"></a> [asg\_termination\_policies](#input\_asg\_termination\_policies) | Termination Policies used by the Autoscaling Group | `list(string)` | <pre>[<br>  "OldestLaunchTemplate"<br>]</pre> | no |
 | <a name="input_cloudwatch_log_group"></a> [cloudwatch\_log\_group](#input\_cloudwatch\_log\_group) | Name of the cloudwatch log group | `string` | n/a | yes |
 | <a name="input_ec2_ebs_volume_type"></a> [ec2\_ebs\_volume\_type](#input\_ec2\_ebs\_volume\_type) | Volume type used in EBS volumes | `string` | `"gp3"` | no |

--- a/autoscaling.tf
+++ b/autoscaling.tf
@@ -15,6 +15,7 @@ resource "aws_autoscaling_group" "this" {
   service_linked_role_arn   = "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/aws-service-role/autoscaling.amazonaws.com/AWSServiceRoleForAutoScaling" // AWS standard role
   metrics_granularity       = var.asg_metrics_granularity
   enabled_metrics           = var.asg_enabled_metrics
+  protect_from_scale_in     = var.asg_protect_from_scale_in
 
   tag {
     key                 = "AmazonECSManaged"

--- a/variables.tf
+++ b/variables.tf
@@ -147,6 +147,12 @@ variable "asg_termination_policies" {
   default     = ["OldestLaunchTemplate"]
 }
 
+variable "asg_protect_from_scale_in" {
+  type        = bool
+  description = "Whether newly launched instances are automatically protected from termination"
+  default     = true
+}
+
 variable "asg_metrics_granularity" {
   type        = string
   description = "Granularity of metrics collected by the Autoscaling Group"


### PR DESCRIPTION
## Description

Fix error `ClientException: The managed termination protection setting for the capacity provider is invalid. To enable managed termination protection for a capacity provider, the Auto Scaling group must have instance protection from scale in enabled.`

## What Changed?

- Add `protect_from_scale_in` argument to `aws_autoscaling_group.this`
- Add input variable `asg_protect_from_scale_in` defaulting to true
- Update `README.md`

## Reason For Change

Managed termination protection allows the AWS Capacity Provider to control which EC2 instances get terminated following a deployment. It seems that to allow this, the ASG must have scale-in protection enabled. This is turned off by default, so the Terraform code must be updated to enable scale-in protection by default.

## Checklist For Reviewer

- [ ] You understand the reason for the change and how it fits into the existing codebase
- [ ] For changes that relate to a deployment, you understand how the change will affect any dependent Live environments
- [ ] You understand the scope of the change and the commit messages reflect this, e.g. where you consider the change to be a breaking change, at least one commit message should include the body "BREAKING CHANGE: ..."
- [ ] You have requested changes to the Pull Request if required, or raised comments suggesting improvements
- [ ] All Review comments and requests for changes have been resolved, or assigned Issues
- [ ] All GitHub Actions jobs pass
