### PR TITLE
Add ability to use an existing certificate

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,8 @@ No modules.
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
+| <a name="input_acm_certificate_arn"></a> [acm\_certificate\_arn](#input\_acm\_certificate\_arn) | ARN of an existing certificate in Amazon Certificate Manager | `string` | `null` | no |
+| <a name="input_acm_create_certificate"></a> [acm\_create\_certificate](#input\_acm\_create\_certificate) | Whether to create a certificate in Amazon Certificate Manager | `bool` | `true` | no |
 | <a name="input_alb_access_logs_bucket"></a> [alb\_access\_logs\_bucket](#input\_alb\_access\_logs\_bucket) | Name of the S3 Bucket for ALB access logs | `string` | `""` | no |
 | <a name="input_alb_access_logs_enabled"></a> [alb\_access\_logs\_enabled](#input\_alb\_access\_logs\_enabled) | Whether to enable access logging for the ALB | `bool` | `false` | no |
 | <a name="input_alb_access_logs_prefix"></a> [alb\_access\_logs\_prefix](#input\_alb\_access\_logs\_prefix) | Prefix for objects in S3 bucket for ALB access logs | `string` | `""` | no |

--- a/acm.tf
+++ b/acm.tf
@@ -5,6 +5,8 @@ locals {
 
 # NOTE see section "Note about Load Balancer Listener" in README.md
 resource "aws_acm_certificate" "default" {
+  count = var.acm_create_certificate ? 1 : 0
+
   domain_name = local.default_domain_name
   subject_alternative_names = [
     local.default_domain_name
@@ -17,7 +19,9 @@ resource "aws_acm_certificate" "default" {
 }
 
 resource "aws_acm_certificate_validation" "default" {
-  certificate_arn         = aws_acm_certificate.default.arn
+  count = var.acm_create_certificate ? 1 : 0
+
+  certificate_arn         = aws_acm_certificate.default.0.arn
   validation_record_fqdns = [for record in aws_route53_record.acm_validation_cname : record.fqdn]
 
   timeouts {

--- a/data.tf
+++ b/data.tf
@@ -38,3 +38,12 @@ data "aws_route53_zone" "existing" {
 
   zone_id = var.route53_zone_id_existing
 }
+
+data "aws_acm_certificate" "existing" {
+  count = var.acm_create_certificate ? 0 : 1
+
+  domain      = var.acm_certificate_domain_name
+  statuses    = ["ISSUED"]
+  types       = ["IMPORTED"]
+  most_recent = true
+}

--- a/data.tf
+++ b/data.tf
@@ -38,12 +38,3 @@ data "aws_route53_zone" "existing" {
 
   zone_id = var.route53_zone_id_existing
 }
-
-data "aws_acm_certificate" "existing" {
-  count = var.acm_create_certificate ? 0 : 1
-
-  domain      = var.acm_certificate_domain_name
-  statuses    = ["ISSUED"]
-  types       = ["IMPORTED"]
-  most_recent = true
-}

--- a/loadbalancer.tf
+++ b/loadbalancer.tf
@@ -28,7 +28,7 @@ resource "aws_lb_listener" "https" {
   port              = 443
   protocol          = "HTTPS"
   ssl_policy        = var.alb_listener_ssl_policy
-  certificate_arn   = aws_acm_certificate.default.arn
+  certificate_arn   = var.acm_create_certificate ? aws_acm_certificate.default.0.arn : data.aws_acm_certificate.existing.0.arn
 
   default_action {
     type = "fixed-response"

--- a/loadbalancer.tf
+++ b/loadbalancer.tf
@@ -28,7 +28,7 @@ resource "aws_lb_listener" "https" {
   port              = 443
   protocol          = "HTTPS"
   ssl_policy        = var.alb_listener_ssl_policy
-  certificate_arn   = var.acm_create_certificate ? aws_acm_certificate.default.0.arn : data.aws_acm_certificate.existing.0.arn
+  certificate_arn   = var.acm_create_certificate ? aws_acm_certificate.default.0.arn : var.acm_certificate_arn
 
   default_action {
     type = "fixed-response"

--- a/route53.tf
+++ b/route53.tf
@@ -7,13 +7,13 @@ resource "aws_route53_zone" "public" {
 }
 
 resource "aws_route53_record" "acm_validation_cname" {
-  for_each = {
-    for dvo in aws_acm_certificate.default.domain_validation_options : dvo.domain_name => {
+  for_each = var.acm_create_certificate ? {
+    for dvo in aws_acm_certificate.default.0.domain_validation_options : dvo.domain_name => {
       name   = dvo.resource_record_name
       record = dvo.resource_record_value
       type   = dvo.resource_record_type
     }
-  }
+  } : {}
 
   allow_overwrite = true
   name            = each.value.name

--- a/variables.tf
+++ b/variables.tf
@@ -275,8 +275,8 @@ variable "acm_create_certificate" {
   default     = true
 }
 
-variable "acm_certificate_domain_name" {
+variable "acm_certificate_arn" {
   type        = string
-  description = "Domain name of an existing certificate in Amazon Certificate Manager. Use if domain name of the certificate is different to domain_name of the service"
+  description = "ARN of an existing certificate in Amazon Certificate Manager"
   default     = null
 }

--- a/variables.tf
+++ b/variables.tf
@@ -268,3 +268,15 @@ variable "waf_ip_set_addresses" {
   description = "List of IPs for WAF IP Set Safelist"
   default     = ["131.111.0.0/16"]
 }
+
+variable "acm_create_certificate" {
+  type        = bool
+  description = "Whether to create a certificate in Amazon Certificate Manager"
+  default     = true
+}
+
+variable "acm_certificate_domain_name" {
+  type        = string
+  description = "Domain name of an existing certificate in Amazon Certificate Manager. Use if domain name of the certificate is different to domain_name of the service"
+  default     = null
+}


### PR DESCRIPTION
## Description

Add ability to use an existing certificate

## What Changed?

- Add input variables `acm_create_certificate` and `acm_certificate_arn`
- Add conditions to `aws_acm_certificate.default` and `aws_acm_certificate_validation.default` resources
- Update `certificate_arn` argument of `aws_lb_listener.https` resource to use condition
- Add condition to `for_each` loop of `aws_route53_record.acm_validation_cname` resource
- Update `README.md`

## Reason For Change

Currently all deployments generate their own certificate in ACM. This places a limitation that the certificates must validated using DNS records backed by a registered domain. This new approach allows domain registration and certificates to be managed outside AWS

## Checklist For Reviewer

- [ ] You understand the reason for the change and how it fits into the existing codebase
- [ ] For changes that relate to a deployment, you understand how the change will affect any dependent Live environments
- [ ] You understand the scope of the change and the commit messages reflect this, e.g. where you consider the change to be a breaking change, at least one commit message should include the body "BREAKING CHANGE: ..."
- [ ] You have requested changes to the Pull Request if required, or raised comments suggesting improvements
- [ ] All Review comments and requests for changes have been resolved, or assigned Issues
- [ ] All GitHub Actions jobs pass
