### PR TITLE
Update WAF to turn off IP set restrictions by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,7 @@ No modules.
 | <a name="input_vpc_peering_vpc_ids"></a> [vpc\_peering\_vpc\_ids](#input\_vpc\_peering\_vpc\_ids) | List of VPC IDS for peering with the VPC | `list(string)` | `[]` | no |
 | <a name="input_vpc_public_subnet_public_ip"></a> [vpc\_public\_subnet\_public\_ip](#input\_vpc\_public\_subnet\_public\_ip) | Whether to automatically assign public IP addresses in the public subnets | `bool` | `false` | no |
 | <a name="input_waf_ip_set_addresses"></a> [waf\_ip\_set\_addresses](#input\_waf\_ip\_set\_addresses) | List of IPs for WAF IP Set Safelist | `list(string)` | <pre>[<br>  "131.111.0.0/16"<br>]</pre> | no |
+| <a name="input_waf_use_ip_restrictions"></a> [waf\_use\_ip\_restrictions](#input\_waf\_use\_ip\_restrictions) | Whether to use IP range restrictions on the default WAF | `bool` | `false` | no |
 
 ## Outputs
 

--- a/variables.tf
+++ b/variables.tf
@@ -263,6 +263,12 @@ variable "cloudwatch_log_group" {
   description = "Name of the cloudwatch log group"
 }
 
+variable "waf_use_ip_restrictions" {
+  type        = bool
+  description = "Whether to use IP range restrictions on the default WAF"
+  default     = false
+}
+
 variable "waf_ip_set_addresses" {
   type        = list(string)
   description = "List of IPs for WAF IP Set Safelist"

--- a/waf.tf
+++ b/waf.tf
@@ -1,4 +1,6 @@
 resource "aws_wafv2_ip_set" "this" {
+  count = var.waf_use_ip_restrictions ? 1 : 0
+
   name               = "${var.name_prefix}-waf-ip-set"
   provider           = aws.us-east-1
   description        = "Managed by Terraform"
@@ -97,24 +99,28 @@ resource "aws_wafv2_web_acl" "this" {
     }
   }
 
-  rule {
-    name     = "${var.name_prefix}-waf-web-acl-rule-ip-set"
-    priority = 3
+  dynamic "rule" {
+    for_each = var.waf_use_ip_restrictions ? [1] : []
 
-    action {
-      allow {}
-    }
+    content {
+      name     = "${var.name_prefix}-waf-web-acl-rule-ip-set"
+      priority = 3
 
-    statement {
-      ip_set_reference_statement {
-        arn = aws_wafv2_ip_set.this.arn
+      action {
+        allow {}
       }
-    }
 
-    visibility_config {
-      cloudwatch_metrics_enabled = true
-      metric_name                = "${var.name_prefix}-waf-web-acl-rule-ip-set"
-      sampled_requests_enabled   = true
+      statement {
+        ip_set_reference_statement {
+          arn = aws_wafv2_ip_set.this.0.arn
+        }
+      }
+
+      visibility_config {
+        cloudwatch_metrics_enabled = true
+        metric_name                = "${var.name_prefix}-waf-web-acl-rule-ip-set"
+        sampled_requests_enabled   = true
+      }
     }
   }
 


### PR DESCRIPTION
## Description

Update WAF to turn off IP set restrictions by default

## What Changed?

- Add input variable `waf_use_ip_restrictions`
- Update `aws_wafv2_ip_set.this` resource to use a condition
- Update rule on `aws_wafv2_web_acl.this` to use condition
- Update `README.md`

## Reason For Change

Currently the default WAF uses an IP set restriction that can't be turned off. This change alters the IP set restriction to use a condition, defaulting to false

## Checklist For Reviewer

- [ ] You understand the reason for the change and how it fits into the existing codebase
- [ ] For changes that relate to a deployment, you understand how the change will affect any dependent Live environments
- [ ] You understand the scope of the change and the commit messages reflect this, e.g. where you consider the change to be a breaking change, at least one commit message should include the body "BREAKING CHANGE: ..."
- [ ] You have requested changes to the Pull Request if required, or raised comments suggesting improvements
- [ ] All Review comments and requests for changes have been resolved, or assigned Issues
- [ ] All GitHub Actions jobs pass
