### PR TITLE
Update default_action block to use dynamic blocks

### DIFF
--- a/waf.tf
+++ b/waf.tf
@@ -16,7 +16,15 @@ resource "aws_wafv2_web_acl" "this" {
   scope       = "CLOUDFRONT"
 
   default_action {
-    block {}
+    dynamic "block" {
+      for_each = var.waf_use_ip_restrictions ? [1] : []
+      content {}
+    }
+
+    dynamic "allow" {
+      for_each = var.waf_use_ip_restrictions ? [] : [1]
+      content {}
+    }
   }
 
   rule {


### PR DESCRIPTION
## Description

Update default_action block to use dynamic blocks

## What Changed?

Update `default_action` block of `aws_wafv2_web_acl.this` resource to use dynamic blocks, responding to condition set by `waf_use_ip_restrictions` input variable

## Reason For Change

Without this change all requests are blocked by default, even where there is no rule overriding the default action, e.g. by using a WAF IP set

## Checklist For Reviewer

- [ ] You understand the reason for the change and how it fits into the existing codebase
- [ ] For changes that relate to a deployment, you understand how the change will affect any dependent Live environments
- [ ] You understand the scope of the change and the commit messages reflect this, e.g. where you consider the change to be a breaking change, at least one commit message should include the body "BREAKING CHANGE: ..."
- [ ] You have requested changes to the Pull Request if required, or raised comments suggesting improvements
- [ ] All Review comments and requests for changes have been resolved, or assigned Issues
- [ ] All GitHub Actions jobs pass
