### PR TITLE
Make VPC Endpoints conditional

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,9 +65,10 @@ No modules.
 | [aws_s3_bucket_versioning.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_versioning) | resource |
 | [aws_security_group.alb](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group) | resource |
 | [aws_security_group.asg](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group) | resource |
+| [aws_security_group.vpc_egress](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group) | resource |
 | [aws_security_group.vpc_endpoints](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group) | resource |
 | [aws_security_group_rule.alb_ingress_cloudfront](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
-| [aws_security_group_rule.asg_egress_all](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
+| [aws_security_group_rule.vpc_egress_https](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
 | [aws_security_group_rule.vpc_endpoint_egress_self](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
 | [aws_security_group_rule.vpc_endpoint_ingress_self](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
 | [aws_security_group_rule.vpc_endpoints_egress_s3](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
@@ -111,7 +112,6 @@ No modules.
 | <a name="input_alb_listener_ssl_policy"></a> [alb\_listener\_ssl\_policy](#input\_alb\_listener\_ssl\_policy) | TLS security policy used by the default ALB Listener | `string` | `"ELBSecurityPolicy-TLS13-1-2-2021-06"` | no |
 | <a name="input_ami_architecture"></a> [ami\_architecture](#input\_ami\_architecture) | Name of the OS Architecture. Note must be compatible with the selected EC2 Instance Type | `string` | `"x86_64"` | no |
 | <a name="input_ami_name_prefix"></a> [ami\_name\_prefix](#input\_ami\_name\_prefix) | Prefix used to find an AMI for use in the Launch Template | `string` | `"amzn2-ami-ecs-hvm-2.0*"` | no |
-| <a name="input_asg_allow_all_egress"></a> [asg\_allow\_all\_egress](#input\_asg\_allow\_all\_egress) | Whether to allow EC2 instances in ASG egress to all targets | `bool` | `true` | no |
 | <a name="input_asg_default_cooldown"></a> [asg\_default\_cooldown](#input\_asg\_default\_cooldown) | Number of seconds between scaling activities | `number` | `300` | no |
 | <a name="input_asg_desired_capacity"></a> [asg\_desired\_capacity](#input\_asg\_desired\_capacity) | Desired number of instances in the Autoscaling Group | `number` | `1` | no |
 | <a name="input_asg_enabled_metrics"></a> [asg\_enabled\_metrics](#input\_asg\_enabled\_metrics) | List of metrics enabled for the Auotscaling Group | `list(string)` | <pre>[<br>  "GroupTotalInstances",<br>  "GroupInServiceInstances",<br>  "GroupTerminatingInstances",<br>  "GroupPendingInstances",<br>  "GroupInServiceCapacity",<br>  "GroupPendingCapacity",<br>  "GroupTotalCapacity",<br>  "GroupTerminatingCapacity"<br>]</pre> | no |
@@ -164,6 +164,7 @@ No modules.
 | <a name="output_route53_public_hosted_zone"></a> [route53\_public\_hosted\_zone](#output\_route53\_public\_hosted\_zone) | Zone ID of the Route 53 Public Hosted Zone |
 | <a name="output_s3_bucket"></a> [s3\_bucket](#output\_s3\_bucket) | Name of the S3 Bucket |
 | <a name="output_s3_bucket_arn"></a> [s3\_bucket\_arn](#output\_s3\_bucket\_arn) | ARN of the S3 Bucket |
+| <a name="output_vpc_egress_security_group_id"></a> [vpc\_egress\_security\_group\_id](#output\_vpc\_egress\_security\_group\_id) | ID of the Security Group for general egress |
 | <a name="output_vpc_endpoint_security_group_id"></a> [vpc\_endpoint\_security\_group\_id](#output\_vpc\_endpoint\_security\_group\_id) | ID of the Security Group for VPC Endpoints |
 | <a name="output_vpc_id"></a> [vpc\_id](#output\_vpc\_id) | VPC ID |
 | <a name="output_vpc_private_subnet_ids"></a> [vpc\_private\_subnet\_ids](#output\_vpc\_private\_subnet\_ids) | Private Subnet IDs |
@@ -227,13 +228,13 @@ The certificate `aws_acm_certificate.default` in this module has no correspondin
 
 ## Outbound Access
 
-The Autoscaling Group used by ECS services is deployed to private subnets. The input variable `asg_allow_all_egress` is used to create a Security Group rule allowing outbound access to the Internet via the NAT Gateway. This defaults to `true`.
+The Autoscaling Group used by ECS services is deployed to private subnets. By default a Security Group rule will be created allowing outbound access to the Internet via the NAT Gateway.
 
-It is possible to deploy services with `asg_allow_all_egress` set to `false`. In this case the input `vpc_endpoints_create` should be set to `true`, otherwise services will not be able to deploy successfully.
+It is possible to deploy services with the input variable `vpc_endpoints_create` set to `true`. This will allow services to access AWS API endpoints using local interfaces inside the VPC. The Route 53 Resolver will resolve AWS API addresses to local IPv4 addresses. This approach should improve the security of deployments by limiting external resources that container services have access to. The list of VPC endpoints can be changed by overriding the input `vpc_endpoint_services`.
 
-Setting `vpc_endpoints_create` to `true` will allow services to access AWS API endpoints using local interfaces inside the VPC. The Route 53 Resolver will resolve AWS API addresses to local IPv4 addresses. This approach should improve the security of deployments by limiting external resources that container services have access to. The list of VPC endpoints can be changed by overriding the input `vpc_endpoint_services`.
+There is a cost impact of using VPC endpoints as there is a standing charge for each endpoint, whether they are used or not. For this reason the input `vpc_endpoints_create` defaults to `false`. When the default value is unchanged, outbound acess will be allowed via the NAT Gateway.
 
-There is a cost impact of using VPC endpoints as there is a standing charge for each endpoint, whether they are used or not. For this reason the input `vpc_endpoints_create` defaults to `false`.
+In versions 1.x.x of this module VPC endpoints were built by default; this changes from version 2.0.0 onwards.
 
 ## GitHub Workflows
 

--- a/autoscaling.tf
+++ b/autoscaling.tf
@@ -50,7 +50,10 @@ resource "aws_launch_template" "this" {
   vpc_security_group_ids = var.vpc_endpoints_create ? [
     aws_security_group.asg.id,
     aws_security_group.vpc_endpoints.0.id
-  ] : [aws_security_group.asg.id]
+    ] : [
+    aws_security_group.asg.id,
+    aws_security_group.vpc_egress.0.id
+  ]
   key_name               = var.ec2_keypair
   update_default_version = true
   user_data = base64encode(templatefile("${path.module}/userdata.sh.ttfpl", {

--- a/autoscaling.tf
+++ b/autoscaling.tf
@@ -47,10 +47,10 @@ resource "aws_launch_template" "this" {
   name          = "${var.name_prefix}-lt"
   instance_type = var.ec2_instance_type
   image_id      = data.aws_ami.ecs_ami.image_id
-  vpc_security_group_ids = [
+  vpc_security_group_ids = var.vpc_endpoints_create ? [
     aws_security_group.asg.id,
-    aws_security_group.vpc_endpoints.id
-  ]
+    aws_security_group.vpc_endpoints.0.id
+  ] : [aws_security_group.asg.id]
   key_name               = var.ec2_keypair
   update_default_version = true
   user_data = base64encode(templatefile("${path.module}/userdata.sh.ttfpl", {

--- a/outputs.tf
+++ b/outputs.tf
@@ -73,6 +73,11 @@ output "vpc_endpoint_security_group_id" {
   description = "ID of the Security Group for VPC Endpoints"
 }
 
+output "vpc_egress_security_group_id" {
+  value       = var.vpc_endpoints_create ? "" : aws_security_group.vpc_egress.0.id
+  description = "ID of the Security Group for general egress"
+}
+
 output "route53_public_hosted_zone" {
   value       = coalescelist(data.aws_route53_zone.existing.*.id, aws_route53_zone.public.*.id)[0]
   description = "Zone ID of the Route 53 Public Hosted Zone"

--- a/outputs.tf
+++ b/outputs.tf
@@ -69,7 +69,7 @@ output "asg_security_group_id" {
 }
 
 output "vpc_endpoint_security_group_id" {
-  value       = aws_security_group.vpc_endpoints.id
+  value       = var.vpc_endpoints_create ? aws_security_group.vpc_endpoints.0.id : ""
   description = "ID of the Security Group for VPC Endpoints"
 }
 

--- a/security_groups.tf
+++ b/security_groups.tf
@@ -23,6 +23,8 @@ resource "aws_security_group" "alb" {
 }
 
 resource "aws_security_group" "vpc_endpoints" {
+  count = var.vpc_endpoints_create ? 1 : 0
+
   name        = "${var.name_prefix}-vpc-endpoints"
   description = "Allows access to VPC Endpoints"
   vpc_id      = aws_vpc.this.id
@@ -59,30 +61,36 @@ resource "aws_security_group_rule" "alb_ingress_cloudfront" {
 }
 
 resource "aws_security_group_rule" "vpc_endpoint_ingress_self" {
+  count = var.vpc_endpoints_create ? 1 : 0
+
   type              = "ingress"
   protocol          = "tcp"
   description       = "VPC Endpoint ingress for ${var.name_prefix}"
-  security_group_id = aws_security_group.vpc_endpoints.id
+  security_group_id = aws_security_group.vpc_endpoints.0.id
   from_port         = 443
   to_port           = 443
   self              = true
 }
 
 resource "aws_security_group_rule" "vpc_endpoint_egress_self" {
+  count = var.vpc_endpoints_create ? 1 : 0
+
   type              = "egress"
   protocol          = "tcp"
   description       = "VPC Endpoint egress for ${var.name_prefix}"
-  security_group_id = aws_security_group.vpc_endpoints.id
+  security_group_id = aws_security_group.vpc_endpoints.0.id
   from_port         = 443
   to_port           = 443
   self              = true
 }
 
 resource "aws_security_group_rule" "vpc_endpoints_egress_s3" {
+  count = var.vpc_endpoints_create ? 1 : 0
+
   type              = "egress"
   protocol          = "tcp"
   description       = "Egress to S3 for ${var.name_prefix}"
-  security_group_id = aws_security_group.vpc_endpoints.id
+  security_group_id = aws_security_group.vpc_endpoints.0.id
   from_port         = 443
   to_port           = 443
   prefix_list_ids   = [data.aws_ec2_managed_prefix_list.s3.id]

--- a/security_groups.tf
+++ b/security_groups.tf
@@ -34,17 +34,29 @@ resource "aws_security_group" "vpc_endpoints" {
   }
 }
 
+resource "aws_security_group" "vpc_egress" {
+  count = var.vpc_endpoints_create ? 0 : 1
+
+  name        = "${var.name_prefix}-vpc-egress"
+  description = "Allows egress from VPC via NAT Gateway"
+  vpc_id      = aws_vpc.this.id
+
+  tags = {
+    Name = "${var.name_prefix}-vpc-egress"
+  }
+}
+
 ################################################################################
 # Security Group Rules
 ################################################################################
 
-resource "aws_security_group_rule" "asg_egress_all" {
-  count = var.asg_allow_all_egress ? 1 : 0
+resource "aws_security_group_rule" "vpc_egress_https" {
+  count = var.vpc_endpoints_create ? 0 : 1
 
   type              = "egress"
   protocol          = "tcp"
   description       = "HTTPS outbound access for ${var.name_prefix}"
-  security_group_id = aws_security_group.asg.id
+  security_group_id = aws_security_group.vpc_egress.0.id
   from_port         = 443
   to_port           = 443
   cidr_blocks       = ["0.0.0.0/0"]

--- a/variables.tf
+++ b/variables.tf
@@ -180,12 +180,6 @@ variable "asg_enabled_metrics" {
   ]
 }
 
-variable "asg_allow_all_egress" {
-  type        = bool
-  description = "Whether to allow EC2 instances in ASG egress to all targets"
-  default     = true
-}
-
 variable "ecs_capacity_provider_status" {
   type        = string
   description = "Enables or disables managed scaling on ASG"

--- a/variables.tf
+++ b/variables.tf
@@ -21,6 +21,12 @@ variable "vpc_public_subnet_public_ip" {
   default     = false
 }
 
+variable "vpc_endpoints_create" {
+  type        = bool
+  description = "Whether to use VPC Endpoints to access AWS services inside the VPC. Note this can have a cost impact"
+  default     = false
+}
+
 variable "vpc_endpoint_dns_record_ip_type" {
   type        = string
   description = "The DNS records created for the endpoint"
@@ -177,7 +183,7 @@ variable "asg_enabled_metrics" {
 variable "asg_allow_all_egress" {
   type        = bool
   description = "Whether to allow EC2 instances in ASG egress to all targets"
-  default     = false
+  default     = true
 }
 
 variable "ecs_capacity_provider_status" {

--- a/vpc.tf
+++ b/vpc.tf
@@ -172,6 +172,8 @@ resource "aws_route" "cudl_vpc_ec2_route_igw" {
 ################################################################################
 
 resource "aws_vpc_endpoint" "s3" {
+  count = var.vpc_endpoints_create ? 1 : 0
+
   vpc_endpoint_type = "Gateway"
   vpc_id            = aws_vpc.this.id
   service_name      = "com.amazonaws.${data.aws_region.current.name}.s3"
@@ -186,9 +188,9 @@ resource "aws_vpc_endpoint" "s3" {
   }
 }
 
-# This is needed for connectivity to aws services in private subnets
 resource "aws_vpc_endpoint" "interface" {
-  for_each          = toset(var.vpc_endpoint_services)
+  for_each = var.vpc_endpoints_create ? toset(var.vpc_endpoint_services) : toset([])
+
   vpc_endpoint_type = "Interface"
   vpc_id            = aws_vpc.this.id
   service_name      = "com.amazonaws.${data.aws_region.current.name}.${each.value}"
@@ -196,7 +198,7 @@ resource "aws_vpc_endpoint" "interface" {
     aws_subnet.private_a.id,
     aws_subnet.private_b.id
   ]
-  security_group_ids  = [aws_security_group.vpc_endpoints.id]
+  security_group_ids  = [aws_security_group.vpc_endpoints.0.id]
   private_dns_enabled = true
 
   dns_options {


### PR DESCRIPTION
## Description

Make VPC Endpoints conditional

**NOTE this is a breaking change due to the removal of the unused input `asg_allow_all_egress`**

## What Changed?

- Add conditions to `aws_vpc_endpoint.s3`, `aws_vpc_endpoint.interface`, `aws_security_group.vpc_endpoints`, `aws_security_group_rule.vpc_endpoint_ingress_self`, `aws_security_group_rule.vpc_endpoint_egress_self` and `aws_security_group_rule.vpc_endpoints_egress_s3 resources`
- Add security group `aws_security_group.vpc_egress`
- Rename `aws_security_group_rule.asg_egress_all` to `aws_security_group_rule.vpc_egress_https`
- Update `vpc_security_group_ids` argument to `aws_launch_template.this`
- Remove input variable `asg_allow_all_egress`
- Add boolean input variable `vpc_endpoints_create`, defaulting to `false`
- Add Outbound Access section to `README.md`
- Update Terraform sections of `README.md`

## Reason For Change

There is a standing charge to VPC endpoints which can have cost implications. This change alters deployments to turn off VPC endpoints by default, retaining the functionality if required by overriding a boolean input `vpc_endpoints_create`. The new section in `README.md` explains the change.

## Checklist For Reviewer

- [ ] You understand the reason for the change and how it fits into the existing codebase
- [ ] For changes that relate to a deployment, you understand how the change will affect any dependent Live environments
- [ ] You understand the scope of the change and the commit messages reflect this, e.g. where you consider the change to be a breaking change, at least one commit message should include the body "BREAKING CHANGE: ..."
- [ ] You have requested changes to the Pull Request if required, or raised comments suggesting improvements
- [ ] All Review comments and requests for changes have been resolved, or assigned Issues
- [ ] All GitHub Actions jobs pass
