### PR TITLE
Allow additional userdata

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,7 @@ No modules.
 | <a name="input_asg_protect_from_scale_in"></a> [asg\_protect\_from\_scale\_in](#input\_asg\_protect\_from\_scale\_in) | Whether newly launched instances are automatically protected from termination | `bool` | `true` | no |
 | <a name="input_asg_termination_policies"></a> [asg\_termination\_policies](#input\_asg\_termination\_policies) | Termination Policies used by the Autoscaling Group | `list(string)` | <pre>[<br>  "OldestLaunchTemplate"<br>]</pre> | no |
 | <a name="input_cloudwatch_log_group"></a> [cloudwatch\_log\_group](#input\_cloudwatch\_log\_group) | Name of the cloudwatch log group | `string` | n/a | yes |
+| <a name="input_ec2_additional_userdata"></a> [ec2\_additional\_userdata](#input\_ec2\_additional\_userdata) | Additional userdata to append to the launch template configuration | `string` | `""` | no |
 | <a name="input_ec2_ebs_volume_type"></a> [ec2\_ebs\_volume\_type](#input\_ec2\_ebs\_volume\_type) | Volume type used in EBS volumes | `string` | `"gp3"` | no |
 | <a name="input_ec2_instance_type"></a> [ec2\_instance\_type](#input\_ec2\_instance\_type) | EC2 Instance type used by EC2 Instances | `string` | `"t3.small"` | no |
 | <a name="input_ec2_keypair"></a> [ec2\_keypair](#input\_ec2\_keypair) | Name of EC2 Keypair for SSH access to EC2 instances | `string` | `null` | no |

--- a/autoscaling.tf
+++ b/autoscaling.tf
@@ -57,7 +57,8 @@ resource "aws_launch_template" "this" {
   key_name               = var.ec2_keypair
   update_default_version = true
   user_data = base64encode(templatefile("${path.module}/userdata.sh.ttfpl", {
-    ecs_cluster = aws_ecs_cluster.this.name
+    ecs_cluster         = aws_ecs_cluster.this.name
+    additional_userdata = var.ec2_additional_userdata
   }))
 
   iam_instance_profile {

--- a/userdata.sh.ttfpl
+++ b/userdata.sh.ttfpl
@@ -5,3 +5,5 @@ echo "ECS_CLUSTER=${ecs_cluster}" >> /etc/ecs/ecs.config
 # NOTE running yum update needs an outbound route to internet. In a private subnet, will need
 # a forward proxy to allow this
 yum update
+
+${additional_userdata}

--- a/variables.tf
+++ b/variables.tf
@@ -105,6 +105,12 @@ variable "ec2_instance_type" {
   default     = "t3.small"
 }
 
+variable "ec2_additional_userdata" {
+  type        = string
+  description = "Additional userdata to append to the launch template configuration"
+  default     = ""
+}
+
 variable "ec2_ebs_volume_type" {
   type        = string
   description = "Volume type used in EBS volumes"


### PR DESCRIPTION
## Description

Allow additional userdata

## What Changed?

- Update `user_data` argument in `aws_launch_template.this` in `autoscaling.tf`
- Update `userdata.sh.ttfpl` with `additional_userdata` template variable
- Add input variable `ec2_additional_userdata`
- Update `README.md`

## Reason For Change

Services may require additional settings to be applied at the host level on startup which can be achieved by adding to the userdata script

## Checklist For Reviewer

- [ ] You understand the reason for the change and how it fits into the existing codebase
- [ ] For changes that relate to a deployment, you understand how the change will affect any dependent Live environments
- [ ] You understand the scope of the change and the commit messages reflect this, e.g. where you consider the change to be a breaking change, at least one commit message should include the body "BREAKING CHANGE: ..."
- [ ] You have requested changes to the Pull Request if required, or raised comments suggesting improvements
- [ ] All Review comments and requests for changes have been resolved, or assigned Issues
- [ ] All GitHub Actions jobs pass
