### PR TITLE
Add optional rate-limiting rule to default WAF

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,7 +145,11 @@ No modules.
 | <a name="input_vpc_peering_vpc_ids"></a> [vpc\_peering\_vpc\_ids](#input\_vpc\_peering\_vpc\_ids) | List of VPC IDS for peering with the VPC | `list(string)` | `[]` | no |
 | <a name="input_vpc_public_subnet_public_ip"></a> [vpc\_public\_subnet\_public\_ip](#input\_vpc\_public\_subnet\_public\_ip) | Whether to automatically assign public IP addresses in the public subnets | `bool` | `false` | no |
 | <a name="input_waf_ip_set_addresses"></a> [waf\_ip\_set\_addresses](#input\_waf\_ip\_set\_addresses) | List of IPs for WAF IP Set Safelist | `list(string)` | <pre>[<br>  "131.111.0.0/16"<br>]</pre> | no |
+| <a name="input_waf_rate_limit"></a> [waf\_rate\_limit](#input\_waf\_rate\_limit) | The limit of requests from a single originating IP address | `number` | `300` | no |
+| <a name="input_waf_rate_limiting_aggregate_key_type"></a> [waf\_rate\_limiting\_aggregate\_key\_type](#input\_waf\_rate\_limiting\_aggregate\_key\_type) | Indicates how to aggregate the request counts. Valid values include: CONSTANT, CUSTOM\_KEYS, FORWARDED\_IP, or IP | `string` | `"IP"` | no |
+| <a name="input_waf_rate_limiting_evaluation_window"></a> [waf\_rate\_limiting\_evaluation\_window](#input\_waf\_rate\_limiting\_evaluation\_window) | Number of seconds during which the WAF should count requests for rate limiting. Valid values are 60, 120, 300 and 600 | `number` | `120` | no |
 | <a name="input_waf_use_ip_restrictions"></a> [waf\_use\_ip\_restrictions](#input\_waf\_use\_ip\_restrictions) | Whether to use IP range restrictions on the default WAF | `bool` | `false` | no |
+| <a name="input_waf_use_rate_limiting"></a> [waf\_use\_rate\_limiting](#input\_waf\_use\_rate\_limiting) | Whether to use rate limiting on the default WAF | `bool` | `false` | no |
 
 ## Outputs
 

--- a/README.md
+++ b/README.md
@@ -148,6 +148,8 @@ No modules.
 | <a name="input_waf_rate_limit"></a> [waf\_rate\_limit](#input\_waf\_rate\_limit) | The limit of requests from a single originating IP address | `number` | `300` | no |
 | <a name="input_waf_rate_limiting_aggregate_key_type"></a> [waf\_rate\_limiting\_aggregate\_key\_type](#input\_waf\_rate\_limiting\_aggregate\_key\_type) | Indicates how to aggregate the request counts. Valid values include: CONSTANT, CUSTOM\_KEYS, FORWARDED\_IP, or IP | `string` | `"IP"` | no |
 | <a name="input_waf_rate_limiting_evaluation_window"></a> [waf\_rate\_limiting\_evaluation\_window](#input\_waf\_rate\_limiting\_evaluation\_window) | Number of seconds during which the WAF should count requests for rate limiting. Valid values are 60, 120, 300 and 600 | `number` | `120` | no |
+| <a name="input_waf_rate_limiting_forwarded_fallback_behavior"></a> [waf\_rate\_limiting\_forwarded\_fallback\_behavior](#input\_waf\_rate\_limiting\_forwarded\_fallback\_behavior) | Behaviour if a request does not contain the specified forwarded header | `string` | `"NO_MATCH"` | no |
+| <a name="input_waf_rate_limiting_forwarded_header_name"></a> [waf\_rate\_limiting\_forwarded\_header\_name](#input\_waf\_rate\_limiting\_forwarded\_header\_name) | Name of the HTTP header to use as an alternative for IP address matching | `string` | `"X-Forwarded-For"` | no |
 | <a name="input_waf_use_ip_restrictions"></a> [waf\_use\_ip\_restrictions](#input\_waf\_use\_ip\_restrictions) | Whether to use IP range restrictions on the default WAF | `bool` | `false` | no |
 | <a name="input_waf_use_rate_limiting"></a> [waf\_use\_rate\_limiting](#input\_waf\_use\_rate\_limiting) | Whether to use rate limiting on the default WAF | `bool` | `false` | no |
 

--- a/variables.tf
+++ b/variables.tf
@@ -275,10 +275,34 @@ variable "waf_use_ip_restrictions" {
   default     = false
 }
 
+variable "waf_use_rate_limiting" {
+  type        = bool
+  description = "Whether to use rate limiting on the default WAF"
+  default     = false
+}
+
 variable "waf_ip_set_addresses" {
   type        = list(string)
   description = "List of IPs for WAF IP Set Safelist"
   default     = ["131.111.0.0/16"]
+}
+
+variable "waf_rate_limit" {
+  type        = number
+  description = "The limit of requests from a single originating IP address"
+  default     = 300
+}
+
+variable "waf_rate_limiting_aggregate_key_type" {
+  type        = string
+  description = "Indicates how to aggregate the request counts. Valid values include: CONSTANT, CUSTOM_KEYS, FORWARDED_IP, or IP"
+  default     = "IP"
+}
+
+variable "waf_rate_limiting_evaluation_window" {
+  type        = number
+  description = "Number of seconds during which the WAF should count requests for rate limiting. Valid values are 60, 120, 300 and 600"
+  default     = 120
 }
 
 variable "acm_create_certificate" {

--- a/variables.tf
+++ b/variables.tf
@@ -305,6 +305,18 @@ variable "waf_rate_limiting_evaluation_window" {
   default     = 120
 }
 
+variable "waf_rate_limiting_forwarded_header_name" {
+  type        = string
+  description = "Name of the HTTP header to use as an alternative for IP address matching"
+  default     = "X-Forwarded-For"
+}
+
+variable "waf_rate_limiting_forwarded_fallback_behavior" {
+  type        = string
+  description = "Behaviour if a request does not contain the specified forwarded header"
+  default     = "NO_MATCH"
+}
+
 variable "acm_create_certificate" {
   type        = bool
   description = "Whether to create a certificate in Amazon Certificate Manager"

--- a/waf.tf
+++ b/waf.tf
@@ -108,35 +108,10 @@ resource "aws_wafv2_web_acl" "this" {
   }
 
   dynamic "rule" {
-    for_each = var.waf_use_ip_restrictions ? [1] : []
-
-    content {
-      name     = "${var.name_prefix}-waf-web-acl-rule-ip-set"
-      priority = 3
-
-      action {
-        allow {}
-      }
-
-      statement {
-        ip_set_reference_statement {
-          arn = aws_wafv2_ip_set.this.0.arn
-        }
-      }
-
-      visibility_config {
-        cloudwatch_metrics_enabled = true
-        metric_name                = "${var.name_prefix}-waf-web-acl-rule-ip-set"
-        sampled_requests_enabled   = true
-      }
-    }
-  }
-
-  dynamic "rule" {
     for_each = var.waf_use_rate_limiting ? [1] : []
     content {
       name     = "${var.name_prefix}-waf-web-acl-rule-rate-limiting"
-      priority = 4
+      priority = 3
 
       action {
         block {}
@@ -153,6 +128,31 @@ resource "aws_wafv2_web_acl" "this" {
       visibility_config {
         cloudwatch_metrics_enabled = true
         metric_name                = "${var.name_prefix}-waf-web-acl-rule-rate-limiting"
+        sampled_requests_enabled   = true
+      }
+    }
+  }
+
+  dynamic "rule" {
+    for_each = var.waf_use_ip_restrictions ? [1] : []
+
+    content {
+      name     = "${var.name_prefix}-waf-web-acl-rule-ip-set"
+      priority = 4
+
+      action {
+        allow {}
+      }
+
+      statement {
+        ip_set_reference_statement {
+          arn = aws_wafv2_ip_set.this.0.arn
+        }
+      }
+
+      visibility_config {
+        cloudwatch_metrics_enabled = true
+        metric_name                = "${var.name_prefix}-waf-web-acl-rule-ip-set"
         sampled_requests_enabled   = true
       }
     }

--- a/waf.tf
+++ b/waf.tf
@@ -132,6 +132,32 @@ resource "aws_wafv2_web_acl" "this" {
     }
   }
 
+  dynamic "rule" {
+    for_each = var.waf_use_rate_limiting ? [1] : []
+    content {
+      name     = "${var.name_prefix}-waf-web-acl-rule-rate-limiting"
+      priority = 4
+
+      action {
+        block {}
+      }
+
+      statement {
+        rate_based_statement {
+          limit                 = var.waf_rate_limit
+          aggregate_key_type    = var.waf_rate_limiting_aggregate_key_type
+          evaluation_window_sec = var.waf_rate_limiting_evaluation_window
+        }
+      }
+
+      visibility_config {
+        cloudwatch_metrics_enabled = true
+        metric_name                = "${var.name_prefix}-waf-web-acl-rule-rate-limiting"
+        sampled_requests_enabled   = true
+      }
+    }
+  }
+
   visibility_config {
     cloudwatch_metrics_enabled = true
     metric_name                = "${var.name_prefix}-waf-web-acl-no-rule"

--- a/waf.tf
+++ b/waf.tf
@@ -122,6 +122,14 @@ resource "aws_wafv2_web_acl" "this" {
           limit                 = var.waf_rate_limit
           aggregate_key_type    = var.waf_rate_limiting_aggregate_key_type
           evaluation_window_sec = var.waf_rate_limiting_evaluation_window
+
+          dynamic "forwarded_ip_config" {
+            for_each = var.waf_rate_limiting_aggregate_key_type == "FORWARDED_IP" ? [1] : []
+            content {
+              header_name       = var.waf_rate_limiting_forwarded_header_name
+              fallback_behavior = var.waf_rate_limiting_forwarded_fallback_behavior
+            }
+          }
         }
       }
 


### PR DESCRIPTION
## Description

Add optional rate-limiting rule to default WAF

## What Changed?

- Add `waf-web-acl-rule-rate-limiting` dynamic rule block
- Add input variables` waf_use_rate_limiting`, `waf_rate_limit`, `waf_rate_limiting_aggregate_key_type` and `waf_rate_limiting_evaluation_window`
 - Update `README.md`

## Reason For Change

This change allows rate limiting from particular Source IPs to be added to the default WAF. Additionally rate limiting using a header is also allowed by setting `waf_rate_limiting_aggregate_key_type` to "FORWARDED_IP" and using the variable `waf_rate_limiting_forwarded_header_name` to control the header used.

## Checklist For Reviewer

- [ ] You understand the reason for the change and how it fits into the existing codebase
- [ ] For changes that relate to a deployment, you understand how the change will affect any dependent Live environments
- [ ] You understand the scope of the change and the commit messages reflect this, e.g. where you consider the change to be a breaking change, at least one commit message should include the body "BREAKING CHANGE: ..."
- [ ] You have requested changes to the Pull Request if required, or raised comments suggesting improvements
- [ ] All Review comments and requests for changes have been resolved, or assigned Issues
- [ ] All GitHub Actions jobs pass
