### PR TITLE
Add aws_security_group_rule.vpc_egress_http

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ No modules.
 | [aws_security_group.vpc_egress](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group) | resource |
 | [aws_security_group.vpc_endpoints](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group) | resource |
 | [aws_security_group_rule.alb_ingress_cloudfront](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
+| [aws_security_group_rule.vpc_egress_http](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
 | [aws_security_group_rule.vpc_egress_https](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
 | [aws_security_group_rule.vpc_endpoint_egress_self](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
 | [aws_security_group_rule.vpc_endpoint_ingress_self](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |

--- a/security_groups.tf
+++ b/security_groups.tf
@@ -62,6 +62,18 @@ resource "aws_security_group_rule" "vpc_egress_https" {
   cidr_blocks       = ["0.0.0.0/0"]
 }
 
+resource "aws_security_group_rule" "vpc_egress_http" {
+  count = var.vpc_endpoints_create ? 0 : 1
+
+  type              = "egress"
+  protocol          = "tcp"
+  description       = "HTTP outbound access for ${var.name_prefix}"
+  security_group_id = aws_security_group.vpc_egress.0.id
+  from_port         = 80
+  to_port           = 80
+  cidr_blocks       = ["0.0.0.0/0"]
+}
+
 resource "aws_security_group_rule" "alb_ingress_cloudfront" {
   type              = "ingress"
   protocol          = "tcp"


### PR DESCRIPTION
## Description

Add security group rule allowing egress on port 80 for HTTP

## What Changed?

- Add `aws_security_group_rule.vpc_egress_http` resource in `security_groups.tf`
- Update `README.md`

## Reason For Change

Currently it is not possibly to get to HTTP links via CUDL Services, such as Codex Zacynthius. This change allows this.

## Checklist For Reviewer

- [ ] You understand the reason for the change and how it fits into the existing codebase
- [ ] For changes that relate to a deployment, you understand how the change will affect any dependent Live environments
- [ ] You understand the scope of the change and the commit messages reflect this, e.g. where you consider the change to be a breaking change, at least one commit message should include the body "BREAKING CHANGE: ..."
- [ ] You have requested changes to the Pull Request if required, or raised comments suggesting improvements
- [ ] All Review comments and requests for changes have been resolved, or assigned Issues
- [ ] All GitHub Actions jobs pass
