### PR TITLE
feat(waf): Add dynamic rule group reference blocks

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,6 +154,7 @@ No modules.
 | <a name="input_waf_rate_limiting_forwarded_fallback_behavior"></a> [waf\_rate\_limiting\_forwarded\_fallback\_behavior](#input\_waf\_rate\_limiting\_forwarded\_fallback\_behavior) | Behaviour if a request does not contain the specified forwarded header | `string` | `"NO_MATCH"` | no |
 | <a name="input_waf_rate_limiting_forwarded_header_name"></a> [waf\_rate\_limiting\_forwarded\_header\_name](#input\_waf\_rate\_limiting\_forwarded\_header\_name) | Name of the HTTP header to use as an alternative for IP address matching | `string` | `"X-Forwarded-For"` | no |
 | <a name="input_waf_use_bot_control"></a> [waf\_use\_bot\_control](#input\_waf\_use\_bot\_control) | Whether to use enhanced bot control on the WAF | `bool` | `false` | no |
+| <a name="input_waf_rule_group_arns"></a> [waf\_rule\_group\_arns](#input\_waf\_rule\_group\_arns) | List of WAF Rule Group ARNs to add as additional rules to the WAF | `list(string)` | `[]` | no |
 | <a name="input_waf_use_ip_restrictions"></a> [waf\_use\_ip\_restrictions](#input\_waf\_use\_ip\_restrictions) | Whether to use IP range restrictions on the default WAF | `bool` | `false` | no |
 | <a name="input_waf_use_rate_limiting"></a> [waf\_use\_rate\_limiting](#input\_waf\_use\_rate\_limiting) | Whether to use rate limiting on the default WAF | `bool` | `false` | no |
 

--- a/variables.tf
+++ b/variables.tf
@@ -335,6 +335,12 @@ variable "waf_bot_control_inspection_level" {
   default     = "COMMON"
 }
 
+variable "waf_rule_group_arns" {
+  type        = list(string)
+  description = "List of WAF Rule Group ARNs to add as additional rules to the WAF"
+  default     = []
+}
+
 variable "acm_create_certificate" {
   type        = bool
   description = "Whether to create a certificate in Amazon Certificate Manager"


### PR DESCRIPTION
## Description

Allow WAF Rule Groups to be referenced by the WAF

## What Changed?

- Add dynamic `rule` block to the `aws_wafv2_web_acl.this` resource creating references to the supplied list of rule group ARNs
- Add input variable `waf_rule_group_arns`
- Update `README.md`

## Reason For Change

This change allows a list of rule groups to be added to the WAF which will allow implementation-specific rules to be added dynamically without needing to create a custom WAF.

## Checklist For Reviewer

- [ ] You understand the reason for the change and how it fits into the existing codebase
- [ ] For changes that relate to a deployment, you understand how the change will affect any dependent Live environments
- [ ] You understand the scope of the change and the commit messages reflect this, e.g. where you consider the change to be a breaking change, at least one commit message should include the body "BREAKING CHANGE: ..."
- [ ] You have requested changes to the Pull Request if required, or raised comments suggesting improvements
- [ ] All Review comments and requests for changes have been resolved, or assigned Issues
- [ ] All GitHub Actions jobs pass
