### PR TITLE
Fix mangled `managed_rule_group_statement` block

### DIFF
--- a/waf.tf
+++ b/waf.tf
@@ -124,23 +124,25 @@ resource "aws_wafv2_web_acl" "this" {
               inspection_level        = var.waf_bot_control_inspection_level
             }
           }
-        }
 
-        dynamic "not_statement" {
-          for_each = var.waf_bot_control_exclusion_header != null ? [1] : []
-          content {
-            statement {
-              byte_match_statement {
-                search_string         = var.waf_bot_control_exclusion_header_value
-                positional_constraint = var.waf_bot_control_exclusion_header_match_type
-                field_to_match {
-                  single_header {
-                    name = var.waf_bot_control_exclusion_header
+          dynamic "scope_down_statement" {
+            for_each = var.waf_bot_control_exclusion_header != null ? [1] : []
+            content {
+              not_statement {
+                statement {
+                  byte_match_statement {
+                    search_string         = var.waf_bot_control_exclusion_header_value
+                    positional_constraint = var.waf_bot_control_exclusion_header_match_type
+                    field_to_match {
+                      single_header {
+                        name = var.waf_bot_control_exclusion_header
+                      }
+                    }
+                    text_transformation {
+                      type     = var.waf_bot_control_exclusion_header_text_transform
+                      priority = 0
+                    }
                   }
-                }
-                text_transformation {
-                  type     = var.waf_bot_control_exclusion_header_text_transform
-                  priority = 0
                 }
               }
             }


### PR DESCRIPTION
## Description

Fix mangled `managed_rule_group_statement` block

## What Changed?

Fix WAF bot control rule by nesting the optional exclusion into a `scope_down_statement` block

## Reason For Change

The previous syntax causes an error on apply: 

```
WAFInvalidParameterException: Error reason: EXACTLY_ONE_CONDITION_REQUIRED, field: STATEMENT, parameter: Statement
```

## Checklist For Reviewer

- [ ] You understand the reason for the change and how it fits into the existing codebase
- [ ] For changes that relate to a deployment, you understand how the change will affect any dependent Live environments
- [ ] You understand the scope of the change and the commit messages reflect this, e.g. where you consider the change to be a breaking change, at least one commit message should include the body "BREAKING CHANGE: ..."
- [ ] You have requested changes to the Pull Request if required, or raised comments suggesting improvements
- [ ] All Review comments and requests for changes have been resolved, or assigned Issues
- [ ] All GitHub Actions jobs pass
