### PR TITLE
Updating to add exclusion type header or uri to WAF bot settings

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -335,28 +335,15 @@ variable "waf_bot_control_inspection_level" {
   default     = "COMMON"
 }
 
-variable "waf_bot_control_exclusion_header" {
-  type        = string
-  description = "Name of header to exclude from WAF bot control"
-  default     = null
-}
-
-variable "waf_bot_control_exclusion_header_value" {
-  type        = string
-  description = "Value of header to exclude from WAF bot control"
-  default     = null
-}
-
-variable "waf_bot_control_exclusion_header_match_type" {
-  type        = string
-  description = "Match type for the bot control exclusion header"
-  default     = "CONTAINS"
-}
-
-variable "waf_bot_control_exclusion_header_text_transform" {
-  type        = string
-  description = "Text transformation to apply before matching the exclusion header for WAF bot control"
-  default     = "NONE"
+variable "waf_bot_control_exclusions" {
+  description = "A list of objects containing information about the WAF exclusions. Can either by a header exclusion (and have 'waf_bot_control_exclusion_header' and 'waf_bot_control_exclusion_header_value' set) OR a URI (and have 'waf_bot_control_exclusion_uri' set)."
+  type = list(object({
+    waf_bot_control_exclusion_header         = optional(string)             // Name of header to exclude from WAF bot control
+    waf_bot_control_exclusion_header_value   = optional(string)             // Value of header to exclude from WAF bot control
+    waf_bot_control_exclusion_match_type     = optional(string, "CONTAINS") // Match type for the bot control exclusion header
+    waf_bot_control_exclusion_text_transform = optional(string, "NONE")     // Text transformation to apply before matching the exclusion header for WAF bot control
+    waf_bot_control_exclusion_uri            = optional(string)             // URI pattern to exclude from waf
+  }))
 }
 
 variable "acm_create_certificate" {


### PR DESCRIPTION
## Description

Updating to add exclusion type header or uri to WAF bot settings

Can be either a header exclusion OR a URI exclusion and expects an array of values for these, e.g. 

waf_bot_control_exclusions = [
  {
    "waf_bot_control_exclusion_header"       = "user-agent",
    "waf_bot_control_exclusion_header_value" = "StatusCake"
  },
  {
    "waf_bot_control_exclusion_uri" = "/iiif/"
  },
  {
    "waf_bot_control_exclusion_uri" = "/v1/"
  }
]

Should express the current production bot exclusions. 

## What Changed?

## Reason For Change

## Checklist For Reviewer

- [ ] You understand the reason for the change and how it fits into the existing codebase
- [ ] For changes that relate to a deployment, you understand how the change will affect any dependent Live environments
- [ ] You understand the scope of the change and the commit messages reflect this, e.g. where you consider the change to be a breaking change, at least one commit message should include the body "BREAKING CHANGE: ..."
- [ ] You have requested changes to the Pull Request if required, or raised comments suggesting improvements
- [ ] All Review comments and requests for changes have been resolved, or assigned Issues
- [ ] All GitHub Actions jobs pass
