### PR TITLE
feat: Add a variable to allow overriding of some WAF action to challe…

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -346,10 +346,10 @@ variable "waf_bot_control_exclusions" {
   }))
 }
 
-variable "waf_bot_control_enable_action_overrides" {
+variable "waf_bot_control_rule_action_overrides" {
   description = "This will prevent the actions that normally cause a capcha response and instead set the level to challenge."
-  type        = bool
-  default     = false
+  type        = list(string)
+  default     = []
 }
 
 variable "acm_create_certificate" {

--- a/variables.tf
+++ b/variables.tf
@@ -346,6 +346,12 @@ variable "waf_bot_control_exclusions" {
   }))
 }
 
+variable "waf_bot_control_enable_action_overrides" {
+  description = "This will prevent the actions that normally cause a capcha response and instead set the level to challenge."
+  type        = bool
+  default     = false
+}
+
 variable "acm_create_certificate" {
   type        = bool
   description = "Whether to create a certificate in Amazon Certificate Manager"

--- a/waf.tf
+++ b/waf.tf
@@ -125,6 +125,26 @@ resource "aws_wafv2_web_acl" "this" {
             }
           }
 
+          dynamic "rule_action_override" {
+            for_each = var.waf_bot_control_enable_action_overrides ? [
+              {
+                name = "TGT_SignalAutomatedBrowser"
+              },
+              {
+                name = "TGT_VolumetricSession"
+              },
+              {
+                name = "GT_SignalBrowserInconsistency"
+              }
+            ] : []
+            content {
+              name = rule_action_override.value.name
+              action_to_use {
+                challenge {}
+              }
+            }
+          }
+
           dynamic "scope_down_statement" {
             for_each = length(var.waf_bot_control_exclusions) > 0 ? [1] : []
             content {

--- a/waf.tf
+++ b/waf.tf
@@ -126,19 +126,9 @@ resource "aws_wafv2_web_acl" "this" {
           }
 
           dynamic "rule_action_override" {
-            for_each = var.waf_bot_control_enable_action_overrides ? [
-              {
-                name = "TGT_SignalAutomatedBrowser"
-              },
-              {
-                name = "TGT_VolumetricSession"
-              },
-              {
-                name = "GT_SignalBrowserInconsistency"
-              }
-            ] : []
+            for_each = toset(var.waf_bot_control_rule_action_overrides)
             content {
-              name = rule_action_override.value.name
+              name = rule_action_override.key
               action_to_use {
                 challenge {}
               }


### PR DESCRIPTION
…nge from captcha

## Description

I have added a variable for the WAF to allow those fields that that are defaulted to "Capcha" to be set to "Challenge" mode instead.  This is used in cases where the interruption to the website from Captcha is too much.

## What Changed?

extra variable added.

## Reason For Change

For CUDL Production user experience

## Checklist For Reviewer

- [ ] You understand the reason for the change and how it fits into the existing codebase
- [ ] For changes that relate to a deployment, you understand how the change will affect any dependent Live environments
- [ ] You understand the scope of the change and the commit messages reflect this, e.g. where you consider the change to be a breaking change, at least one commit message should include the body "BREAKING CHANGE: ..."
- [ ] You have requested changes to the Pull Request if required, or raised comments suggesting improvements
- [ ] All Review comments and requests for changes have been resolved, or assigned Issues
- [ ] All GitHub Actions jobs pass
