### PR TITLE
Feature/s3 bucket name override

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -2,6 +2,8 @@
 
 ## What Changed?
 
+## Breaking Changes
+
 ## Reason For Change
 
 ## Checklist For Reviewer

--- a/README.md
+++ b/README.md
@@ -137,6 +137,7 @@ No modules.
 | <a name="input_route53_zone_domain_name"></a> [route53\_zone\_domain\_name](#input\_route53\_zone\_domain\_name) | Name of the Domain Name used by the Route 53 Zone. Trailing dots are ignored | `string` | `null` | no |
 | <a name="input_route53_zone_force_destroy"></a> [route53\_zone\_force\_destroy](#input\_route53\_zone\_force\_destroy) | Whether to destroy the Route 53 Zone although records may still exist | `bool` | `false` | no |
 | <a name="input_route53_zone_id_existing"></a> [route53\_zone\_id\_existing](#input\_route53\_zone\_id\_existing) | ID of an existing Route 53 Hosted zone as an alternative to creating a hosted zone | `string` | `null` | no |
+| <a name="input_s3_bucket_create"></a> [s3\_bucket\_create](#input\_s3\_bucket\_create) | Whether to create an S3 bucket to associate with the deployment | `bool` | `true` | no |
 | <a name="input_s3_bucket_force_destroy"></a> [s3\_bucket\_force\_destroy](#input\_s3\_bucket\_force\_destroy) | Whether to allow a non-empty bucket to be destroyed | `bool` | `false` | no |
 | <a name="input_s3_bucket_name"></a> [s3\_bucket\_name](#input\_s3\_bucket\_name) | Optional name of the S3 bucket to override default value | `string` | `null` | no |
 | <a name="input_s3_bucket_versioning_enabled"></a> [s3\_bucket\_versioning\_enabled](#input\_s3\_bucket\_versioning\_enabled) | Whether to enable S3 bucket versioning | `bool` | `true` | no |

--- a/README.md
+++ b/README.md
@@ -138,6 +138,7 @@ No modules.
 | <a name="input_route53_zone_force_destroy"></a> [route53\_zone\_force\_destroy](#input\_route53\_zone\_force\_destroy) | Whether to destroy the Route 53 Zone although records may still exist | `bool` | `false` | no |
 | <a name="input_route53_zone_id_existing"></a> [route53\_zone\_id\_existing](#input\_route53\_zone\_id\_existing) | ID of an existing Route 53 Hosted zone as an alternative to creating a hosted zone | `string` | `null` | no |
 | <a name="input_s3_bucket_force_destroy"></a> [s3\_bucket\_force\_destroy](#input\_s3\_bucket\_force\_destroy) | Whether to allow a non-empty bucket to be destroyed | `bool` | `false` | no |
+| <a name="input_s3_bucket_name"></a> [s3\_bucket\_name](#input\_s3\_bucket\_name) | Optional name of the S3 bucket to override default value | `string` | `null` | no |
 | <a name="input_s3_bucket_versioning_enabled"></a> [s3\_bucket\_versioning\_enabled](#input\_s3\_bucket\_versioning\_enabled) | Whether to enable S3 bucket versioning | `bool` | `true` | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | Map of tags for adding to resources | `map(string)` | `{}` | no |
 | <a name="input_vpc_cidr_block"></a> [vpc\_cidr\_block](#input\_vpc\_cidr\_block) | CIDR block for the VPC | `string` | `"10.0.0.0/16"` | no |
@@ -181,6 +182,7 @@ No modules.
 | <a name="output_route53_public_hosted_zone"></a> [route53\_public\_hosted\_zone](#output\_route53\_public\_hosted\_zone) | Zone ID of the Route 53 Public Hosted Zone |
 | <a name="output_s3_bucket"></a> [s3\_bucket](#output\_s3\_bucket) | Name of the S3 Bucket |
 | <a name="output_s3_bucket_arn"></a> [s3\_bucket\_arn](#output\_s3\_bucket\_arn) | ARN of the S3 Bucket |
+| <a name="output_vpc_availability_zones"></a> [vpc\_availability\_zones](#output\_vpc\_availability\_zones) | List of availability zones enabled in VPC |
 | <a name="output_vpc_egress_security_group_id"></a> [vpc\_egress\_security\_group\_id](#output\_vpc\_egress\_security\_group\_id) | ID of the Security Group for general egress |
 | <a name="output_vpc_endpoint_security_group_id"></a> [vpc\_endpoint\_security\_group\_id](#output\_vpc\_endpoint\_security\_group\_id) | ID of the Security Group for VPC Endpoints |
 | <a name="output_vpc_id"></a> [vpc\_id](#output\_vpc\_id) | VPC ID |

--- a/outputs.tf
+++ b/outputs.tf
@@ -13,6 +13,11 @@ output "vpc_private_subnet_ids" {
   description = "Private Subnet IDs"
 }
 
+output "vpc_availability_zones" {
+  value       = slice(data.aws_availability_zones.available.names, 0, var.vpc_subnets_count)
+  description = "List of availability zones enabled in VPC"
+}
+
 output "ecs_cluster_name" {
   value       = aws_ecs_cluster.this.name
   description = "Name of the ECS Cluster"

--- a/outputs.tf
+++ b/outputs.tf
@@ -34,12 +34,12 @@ output "ecs_capacity_provider_name" {
 }
 
 output "s3_bucket" {
-  value       = aws_s3_bucket.this.id
+  value       = var.s3_bucket_create ? aws_s3_bucket.this.0.id : ""
   description = "Name of the S3 Bucket"
 }
 
 output "s3_bucket_arn" {
-  value       = aws_s3_bucket.this.arn
+  value       = var.s3_bucket_create ? aws_s3_bucket.this.0.arn : ""
   description = "ARN of the S3 Bucket"
 }
 

--- a/s3.tf
+++ b/s3.tf
@@ -1,5 +1,5 @@
 resource "aws_s3_bucket" "this" {
-  bucket        = var.name_prefix
+  bucket        = var.s3_bucket_name != null ? var.s3_bucket_name : var.name_prefix
   force_destroy = var.s3_bucket_force_destroy
 }
 

--- a/s3.tf
+++ b/s3.tf
@@ -1,10 +1,14 @@
 resource "aws_s3_bucket" "this" {
+  count = var.s3_bucket_create ? 1 : 0
+
   bucket        = var.s3_bucket_name != null ? var.s3_bucket_name : var.name_prefix
   force_destroy = var.s3_bucket_force_destroy
 }
 
 resource "aws_s3_bucket_versioning" "this" {
-  bucket = aws_s3_bucket.this.id
+  count = var.s3_bucket_create ? 1 : 0
+
+  bucket = aws_s3_bucket.this.0.id
   versioning_configuration {
     status = var.s3_bucket_versioning_enabled ? "Enabled" : "Disabled"
   }

--- a/variables.tf
+++ b/variables.tf
@@ -87,6 +87,12 @@ variable "route53_zone_id_existing" {
   default     = null
 }
 
+variable "s3_bucket_create" {
+  type        = bool
+  description = "Whether to create an S3 bucket to associate with the deployment"
+  default     = true
+}
+
 variable "s3_bucket_name" {
   type        = string
   description = "Optional name of the S3 bucket to override default value"

--- a/variables.tf
+++ b/variables.tf
@@ -87,6 +87,12 @@ variable "route53_zone_id_existing" {
   default     = null
 }
 
+variable "s3_bucket_name" {
+  type        = string
+  description = "Optional name of the S3 bucket to override default value"
+  default     = null
+}
+
 variable "s3_bucket_versioning_enabled" {
   type        = bool
   description = "Whether to enable S3 bucket versioning"


### PR DESCRIPTION
## Description

Allow S3 bucket creation to be turned off. Also allow the bucket name to be overridden.

## What Changed?

- Add count argument to `aws_s3_bucket.this` and `aws_s3_bucket_versioning.this`
- Add input variables `s3_bucket_create` defaulting to `true`, and `s3_bucket_name` defaulting to `null`
- Add output `vpc_availability_zones`
- Update `README.md`

## Breaking Changes

None

## Reason For Change

- The S3 bucket may not be needed for all deployments, hence allowing it to be turned off. Also the default name may conflict with an existing bucket (names must be globally unique) so this change allows an override.
- The `vpc_availability_zones` output makes creation of resources referring to availability zones, such as RDS clusters, to be more dynamic. 

## Checklist For Reviewer

- [ ] You understand the reason for the change and how it fits into the existing codebase
- [ ] For changes that relate to a deployment, you understand how the change will affect any dependent Live environments
- [ ] You understand the scope of the change and the commit messages reflect this, e.g. where you consider the change to be a breaking change, at least one commit message should include the body "BREAKING CHANGE: ..."
- [ ] You have requested changes to the Pull Request if required, or raised comments suggesting improvements
- [ ] All Review comments and requests for changes have been resolved, or assigned Issues
- [ ] All GitHub Actions jobs pass
