### PR TITLE
Enable ECS Manage Instances

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,8 +41,10 @@ No modules.
 | [aws_ecs_cluster_capacity_providers.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ecs_cluster_capacity_providers) | resource |
 | [aws_eip.nat](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/eip) | resource |
 | [aws_iam_instance_profile.instance](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_instance_profile) | resource |
+| [aws_iam_role.infrastructure](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
 | [aws_iam_role.instance](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
 | [aws_iam_role_policy_attachment.ec2_container_service](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
+| [aws_iam_role_policy_attachment.infrastructure](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_iam_role_policy_attachment.ssm_managed_instance](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_internet_gateway.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/internet_gateway) | resource |
 | [aws_launch_template.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/launch_template) | resource |
@@ -127,11 +129,18 @@ No modules.
 | <a name="input_ec2_ebs_volume_type"></a> [ec2\_ebs\_volume\_type](#input\_ec2\_ebs\_volume\_type) | Volume type used in EBS volumes | `string` | `"gp3"` | no |
 | <a name="input_ec2_instance_type"></a> [ec2\_instance\_type](#input\_ec2\_instance\_type) | EC2 Instance type used by EC2 Instances | `string` | `"t3.small"` | no |
 | <a name="input_ec2_keypair"></a> [ec2\_keypair](#input\_ec2\_keypair) | Name of EC2 Keypair for SSH access to EC2 instances | `string` | `null` | no |
+| <a name="input_ecs_capacity_provider_managed_instances"></a> [ecs\_capacity\_provider\_managed\_instances](#input\_ecs\_capacity\_provider\_managed\_instances) | Whether to allow the ECS capacity provider to manage instances | `bool` | `false` | no |
 | <a name="input_ecs_capacity_provider_managed_termination_protection"></a> [ecs\_capacity\_provider\_managed\_termination\_protection](#input\_ecs\_capacity\_provider\_managed\_termination\_protection) | Enables or disables container-aware termination of instances in the ASG when scale-in happens | `string` | `"ENABLED"` | no |
 | <a name="input_ecs_capacity_provider_status"></a> [ecs\_capacity\_provider\_status](#input\_ecs\_capacity\_provider\_status) | Enables or disables managed scaling on ASG | `string` | `"ENABLED"` | no |
 | <a name="input_ecs_capacity_provider_target_capacity_percent"></a> [ecs\_capacity\_provider\_target\_capacity\_percent](#input\_ecs\_capacity\_provider\_target\_capacity\_percent) | Percentage target capacity utilization for the autscaling group instances | `number` | `100` | no |
 | <a name="input_ecs_default_capacity_provider_strategy_base"></a> [ecs\_default\_capacity\_provider\_strategy\_base](#input\_ecs\_default\_capacity\_provider\_strategy\_base) | Designates how many tasks, at a minimum, to run on the default capacity provider | `number` | `1` | no |
 | <a name="input_ecs_default_capacity_provider_strategy_weight"></a> [ecs\_default\_capacity\_provider\_strategy\_weight](#input\_ecs\_default\_capacity\_provider\_strategy\_weight) | Designates the percentage of the total number of tasks that should use the default capacity provider | `number` | `100` | no |
+| <a name="input_ecs_managed_instances_include_burstable"></a> [ecs\_managed\_instances\_include\_burstable](#input\_ecs\_managed\_instances\_include\_burstable) | Whether to include burstable performance types in managed instances | `bool` | `true` | no |
+| <a name="input_ecs_managed_instances_memory_max"></a> [ecs\_managed\_instances\_memory\_max](#input\_ecs\_managed\_instances\_memory\_max) | Maximum amount of memory when using ECS managed instances, in Mebibytes | `number` | `16000` | no |
+| <a name="input_ecs_managed_instances_memory_min"></a> [ecs\_managed\_instances\_memory\_min](#input\_ecs\_managed\_instances\_memory\_min) | Minumum amount of memory when using ECS managed instances, in Mebibytes | `number` | `2000` | no |
+| <a name="input_ecs_managed_instances_storage_size"></a> [ecs\_managed\_instances\_storage\_size](#input\_ecs\_managed\_instances\_storage\_size) | Storage size in Gebibytes for ECS managed instances | `number` | `30` | no |
+| <a name="input_ecs_managed_instances_vcpu_max"></a> [ecs\_managed\_instances\_vcpu\_max](#input\_ecs\_managed\_instances\_vcpu\_max) | Maximum number of vcpus when using ECS managed instances | `number` | `4` | no |
+| <a name="input_ecs_managed_instances_vcpu_min"></a> [ecs\_managed\_instances\_vcpu\_min](#input\_ecs\_managed\_instances\_vcpu\_min) | Minumum number of vcpus when using ECS managed instances | `number` | `2` | no |
 | <a name="input_name_prefix"></a> [name\_prefix](#input\_name\_prefix) | Name prefix of the ECS Cluster and associated resources | `string` | n/a | yes |
 | <a name="input_route53_delegation_set_id"></a> [route53\_delegation\_set\_id](#input\_route53\_delegation\_set\_id) | The ID of the reusable delegation set whose NS records should be assigned to the hosted zone | `string` | `null` | no |
 | <a name="input_route53_zone_domain_name"></a> [route53\_zone\_domain\_name](#input\_route53\_zone\_domain\_name) | Name of the Domain Name used by the Route 53 Zone. Trailing dots are ignored | `string` | `null` | no |

--- a/README.md
+++ b/README.md
@@ -41,10 +41,12 @@ No modules.
 | [aws_ecs_cluster_capacity_providers.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ecs_cluster_capacity_providers) | resource |
 | [aws_eip.nat](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/eip) | resource |
 | [aws_iam_instance_profile.instance](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_instance_profile) | resource |
+| [aws_iam_policy.infrastructure_extra](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
 | [aws_iam_role.infrastructure](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
 | [aws_iam_role.instance](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
 | [aws_iam_role_policy_attachment.ec2_container_service](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_iam_role_policy_attachment.infrastructure](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
+| [aws_iam_role_policy_attachment.infrastructure_extra](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_iam_role_policy_attachment.ssm_managed_instance](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_internet_gateway.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/internet_gateway) | resource |
 | [aws_launch_template.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/launch_template) | resource |
@@ -88,6 +90,8 @@ No modules.
 | [aws_ec2_managed_prefix_list.cloudfront](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/ec2_managed_prefix_list) | data source |
 | [aws_ec2_managed_prefix_list.s3](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/ec2_managed_prefix_list) | data source |
 | [aws_iam_policy_document.assume_role_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+| [aws_iam_policy_document.assume_role_policy_ecs](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+| [aws_iam_policy_document.infrastructure_extra](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_kms_alias.ebs](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/kms_alias) | data source |
 | [aws_region.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/region) | data source |
 | [aws_route53_zone.existing](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/route53_zone) | data source |

--- a/autoscaling.tf
+++ b/autoscaling.tf
@@ -1,7 +1,9 @@
 resource "aws_autoscaling_group" "this" {
+  count = var.ecs_capacity_provider_managed_instances ? 0 : 1
+
   name = "${var.name_prefix}-asg"
   launch_template {
-    id      = aws_launch_template.this.id
+    id      = aws_launch_template.this.0.id
     version = "$Latest"
   }
   min_size                  = var.asg_min_size
@@ -47,6 +49,8 @@ resource "aws_autoscaling_group" "this" {
 }
 
 resource "aws_launch_template" "this" {
+  count = var.ecs_capacity_provider_managed_instances ? 0 : 1
+
   name          = "${var.name_prefix}-lt"
   instance_type = var.ec2_instance_type
   image_id      = data.aws_ami.ecs_ami.image_id

--- a/ecs.tf
+++ b/ecs.tf
@@ -5,17 +5,63 @@ resource "aws_ecs_cluster" "this" {
 # NOTE this resource automatically creates an ECS managed Scaling Policy
 # in the Auto Scaling Group
 resource "aws_ecs_capacity_provider" "this" {
-  name = "${var.name_prefix}-capacity-provider"
+  name    = "${var.name_prefix}-capacity-provider"
+  cluster = var.ecs_capacity_provider_managed_instances ? aws_ecs_cluster.this.name : null
 
-  auto_scaling_group_provider {
-    auto_scaling_group_arn         = aws_autoscaling_group.this.arn
-    managed_termination_protection = var.ecs_capacity_provider_managed_termination_protection
+  dynamic "auto_scaling_group_provider" {
+    for_each = var.ecs_capacity_provider_managed_instances ? [] : [1]
 
-    managed_scaling {
-      maximum_scaling_step_size = 2
-      minimum_scaling_step_size = 1
-      status                    = var.ecs_capacity_provider_status
-      target_capacity           = var.ecs_capacity_provider_target_capacity_percent
+    content {
+      auto_scaling_group_arn         = aws_autoscaling_group.this.0.arn
+      managed_termination_protection = var.ecs_capacity_provider_managed_termination_protection
+
+      managed_scaling {
+        maximum_scaling_step_size = 2
+        minimum_scaling_step_size = 1
+        status                    = var.ecs_capacity_provider_status
+        target_capacity           = var.ecs_capacity_provider_target_capacity_percent
+      }
+    }
+  }
+
+  dynamic "managed_instances_provider" {
+    for_each = var.ecs_capacity_provider_managed_instances ? [1] : [0]
+
+    content {
+      infrastructure_role_arn = aws_iam_role.infrastructure.0.arn
+      propagate_tags          = "CAPACITY_PROVIDER"
+
+      instance_launch_template {
+        ec2_instance_profile_arn = aws_iam_instance_profile.instance.arn
+        instance_requirements {
+          burstable_performance = var.ecs_managed_instances_include_burstable ? "included" : "excluded"
+
+          memory_mib {
+            min = var.ecs_managed_instances_memory_min
+            max = var.ecs_managed_instances_memory_max
+          }
+
+          vcpu_count {
+            min = var.ecs_managed_instances_vcpu_min
+            max = var.ecs_managed_instances_vcpu_max
+          }
+        }
+
+        network_configuration {
+          security_groups = var.vpc_endpoints_create ? [
+            aws_security_group.asg.id,
+            aws_security_group.vpc_endpoints.0.id
+            ] : [
+            aws_security_group.asg.id,
+            aws_security_group.vpc_egress.0.id
+          ]
+          subnets = aws_subnet.private.*.id
+        }
+
+        storage_configuration {
+          storage_size_gib = var.ecs_managed_instances_storage_size
+        }
+      }
     }
   }
 }

--- a/ecs.tf
+++ b/ecs.tf
@@ -25,7 +25,7 @@ resource "aws_ecs_capacity_provider" "this" {
   }
 
   dynamic "managed_instances_provider" {
-    for_each = var.ecs_capacity_provider_managed_instances ? [1] : [0]
+    for_each = var.ecs_capacity_provider_managed_instances ? [1] : []
 
     content {
       infrastructure_role_arn = aws_iam_role.infrastructure.0.arn

--- a/iam.tf
+++ b/iam.tf
@@ -61,9 +61,46 @@ resource "aws_iam_role" "infrastructure" {
   }
 }
 
+# this is needed because the AmazonECSInfrastructureRolePolicyForManagedInstances policy
+# limits the names of instance roles
+
+data "aws_iam_policy_document" "infrastructure_extra" {
+  count = var.ecs_capacity_provider_managed_instances ? 1 : 0
+
+  statement {
+    actions   = ["iam:PassRole"]
+    resources = [aws_iam_role.instance.arn]
+
+    condition {
+      test     = "StringEquals"
+      variable = "iam:PassedToService"
+      values   = ["ec2.amazonaws.com"]
+    }
+  }
+}
+
+resource "aws_iam_policy" "infrastructure_extra" {
+  count = var.ecs_capacity_provider_managed_instances ? 1 : 0
+
+  name        = trimprefix(substr("${var.name_prefix}-infrastructure-extra", -64, -1), "-")
+  path        = "/"
+  description = "Additional permissions for ${aws_iam_role.infrastructure.0.name}"
+  policy      = data.aws_iam_policy_document.infrastructure_extra.0.json
+  tags = {
+    Name = trimprefix(substr("${var.name_prefix}-infrastructure-extra", -64, -1), "-")
+  }
+}
+
 resource "aws_iam_role_policy_attachment" "infrastructure" {
   count = var.ecs_capacity_provider_managed_instances ? 1 : 0
 
   role       = aws_iam_role.infrastructure.0.name
   policy_arn = "arn:aws:iam::aws:policy/AmazonECSInfrastructureRolePolicyForManagedInstances"
+}
+
+resource "aws_iam_role_policy_attachment" "infrastructure_extra" {
+  count = var.ecs_capacity_provider_managed_instances ? 1 : 0
+
+  role       = aws_iam_role.infrastructure.0.name
+  policy_arn = aws_iam_policy.infrastructure_extra.0.arn
 }

--- a/iam.tf
+++ b/iam.tf
@@ -34,3 +34,36 @@ resource "aws_iam_instance_profile" "instance" {
   name = "${var.name_prefix}-instance-profile"
   role = aws_iam_role.instance.name
 }
+
+data "aws_iam_policy_document" "assume_role_policy_ecs" {
+  count = var.ecs_capacity_provider_managed_instances ? 1 : 0
+
+  statement {
+    actions = ["sts:AssumeRole"]
+
+    principals {
+      type        = "Service"
+      identifiers = ["ecs.amazonaws.com"]
+    }
+  }
+}
+
+resource "aws_iam_role" "infrastructure" {
+  count = var.ecs_capacity_provider_managed_instances ? 1 : 0
+
+  path                 = "/"
+  name                 = trimprefix(substr("${var.name_prefix}-infrastructure", -64, -1), "-")
+  assume_role_policy   = data.aws_iam_policy_document.assume_role_policy_ecs.0.json
+  max_session_duration = 3600
+
+  tags = {
+    Name = "${var.name_prefix}-infrastructure-role"
+  }
+}
+
+resource "aws_iam_role_policy_attachment" "infrastructure" {
+  count = var.ecs_capacity_provider_managed_instances ? 1 : 0
+
+  role       = aws_iam_role.infrastructure.0.name
+  policy_arn = "arn:aws:iam::aws:policy/AmazonECSInfrastructureRolePolicyForManagedInstances"
+}

--- a/outputs.tf
+++ b/outputs.tf
@@ -59,7 +59,7 @@ output "alb_dns_name" {
 }
 
 output "asg_name" {
-  value       = aws_autoscaling_group.this.name
+  value       = var.ecs_capacity_provider_managed_instances ? "" : aws_autoscaling_group.this.0.name
   description = "Name of the Auto Scaling Group"
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -252,6 +252,48 @@ variable "ecs_default_capacity_provider_strategy_weight" {
   default     = 100
 }
 
+variable "ecs_capacity_provider_managed_instances" {
+  type        = bool
+  description = "Whether to allow the ECS capacity provider to manage instances"
+  default     = false
+}
+
+variable "ecs_managed_instances_include_burstable" {
+  type        = bool
+  description = "Whether to include burstable performance types in managed instances"
+  default     = true
+}
+
+variable "ecs_managed_instances_memory_min" {
+  type        = number
+  description = "Minumum amount of memory when using ECS managed instances, in Mebibytes"
+  default     = 2000
+}
+
+variable "ecs_managed_instances_memory_max" {
+  type        = number
+  description = "Maximum amount of memory when using ECS managed instances, in Mebibytes"
+  default     = 16000
+}
+
+variable "ecs_managed_instances_vcpu_min" {
+  type        = number
+  description = "Minumum number of vcpus when using ECS managed instances"
+  default     = 2
+}
+
+variable "ecs_managed_instances_vcpu_max" {
+  type        = number
+  description = "Maximum number of vcpus when using ECS managed instances"
+  default     = 4
+}
+
+variable "ecs_managed_instances_storage_size" {
+  type        = number
+  description = "Storage size in Gebibytes for ECS managed instances"
+  default     = 30
+}
+
 variable "alb_internal" {
   type        = bool
   description = "Whether the ALB should be internal (not public facing)"


### PR DESCRIPTION
## Description

Enable ECS Manage Instances. See https://aws.amazon.com/ecs/managed-instances/

## What Changed?

- Add `managed_instances_provider` block to `aws_ecs_capacity_provider.this`
- Add `aws_iam_role.infrastructure resource`
- Add input variables for ECS managed instances
-  Add aws_`iam_policy.infrastructure_extra`, `data.aws_iam_policy_document.infrastructure_extra` and `aws_iam_role_policy_attachment.infrastructure_extra`
- Update `README.md`

## Breaking Changes

N/A

## Reason For Change

This change enables AWS's new ECS Manage Instances feature, which should give greater control over instance sizes with a mixed deployment of several instance types

## Checklist For Reviewer

- [ ] You understand the reason for the change and how it fits into the existing codebase
- [ ] For changes that relate to a deployment, you understand how the change will affect any dependent Live environments
- [ ] You understand the scope of the change and the commit messages reflect this, e.g. where you consider the change to be a breaking change, at least one commit message should include the body "BREAKING CHANGE: ..."
- [ ] You have requested changes to the Pull Request if required, or raised comments suggesting improvements
- [ ] All Review comments and requests for changes have been resolved, or assigned Issues
- [ ] All GitHub Actions jobs pass
